### PR TITLE
Add links to other Rust ABI-related work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,9 @@ However, our experience in software engineering has shown that type-size matters
 My hope with `stabby` comes in two flavors:
 - Adoption in the Rust ecosystem: this is my least favorite option, but this would at least let people have a better time with Rust in situations where they need dynamic linkage.
 - Triggering a discussion about providing not a stable, but versionned ABI for Rust: `stabby` essentially provides a versionned ABI already through the selected version of the `stabby-abi` crate. However, having a library implement type-layout, which is normally the compiler's job, forces abi-stability to be per-type explicit, instead of applicable to a whole compilation unit. In my opinion, a `abi = "1.xx"` (where `xx` would be a subset of `rustc`'s version that the compiler team is willing to support for a given amount of time) key in the cargo manifest would be a much better way to do this.
+
+# Related work
+
+ * [Rust ABI Wiki](https://slightknack.github.io/rust-abi-wiki/intro/intro.html)
+ * "[Experimental feature gate proposal `interoperable_abi` #105586](https://github.com/rust-lang/rust/pull/105586)"
+ * "[RFC: result_ffi_guarantees #3391](https://github.com/rust-lang/rfcs/pull/3391)"


### PR DESCRIPTION
Given the second point of the `stabby` "manifesto" I thought links to some other Rust ABI/FFI/stability-related discussions of which I'm aware would be useful breadcrumbs for cross-pollination and other mixed metaphors. :)