### PR TITLE
Fix abi to spec

### DIFF
--- a/stabby-abi/Cargo.toml
+++ b/stabby-abi/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "stabby-abi"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = { workspace = true }
 license = { workspace = true }

--- a/stabby-abi/src/enums/mod.rs
+++ b/stabby-abi/src/enums/mod.rs
@@ -37,8 +37,8 @@ pub trait IDiscriminant: IStable {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BitDiscriminant {
-    Err = 0,
-    Ok = 1,
+    Err = 1,
+    Ok = 0,
 }
 unsafe impl IStable for BitDiscriminant {
     type Size = U1;

--- a/stabby-abi/src/lib.rs
+++ b/stabby-abi/src/lib.rs
@@ -292,5 +292,5 @@ pub mod str;
 
 pub use istable::{Array, End, IStable};
 
-pub(crate) mod istable;
+pub mod istable;
 pub type NonZeroHole = U0;

--- a/stabby-abi/src/stable_impls.rs
+++ b/stabby-abi/src/stable_impls.rs
@@ -488,6 +488,12 @@ mod cfgalloc {
     unsafe impl<T: IStable> IStable for alloc::sync::Weak<T> {
         same_as!(core::ptr::NonNull<T>, "alloc::sync::Weak", T);
     }
+    unsafe impl<T: IStable> IStable for alloc::rc::Rc<T> {
+        same_as!(core::ptr::NonNull<T>, "alloc::rc::Rc", T);
+    }
+    unsafe impl<T: IStable> IStable for alloc::rc::Weak<T> {
+        same_as!(core::ptr::NonNull<T>, "alloc::rc::Weak", T);
+    }
 }
 
 macro_rules! fnstable {

--- a/stabby-abi/src/typenum2/unsigned.rs
+++ b/stabby-abi/src/typenum2/unsigned.rs
@@ -270,7 +270,7 @@ unsafe impl<L: IStable + Copy + Default> IStable for OneMoreByte<L> {
     type Size = <L::Size as IUnsignedBase>::Increment;
     type Align = L::Align;
     type ForbiddenValues = L::ForbiddenValues;
-    type UnusedBits = Array<L::Size, UxFF, L::UnusedBits>;
+    type UnusedBits = <L::UnusedBits as IBitMask>::BitOr<Array<L::Size, UxFF, End>>;
     type HasExactlyOneNiche = L::HasExactlyOneNiche;
     primitive_report!("OneMoreByte");
 }

--- a/stabby-macros/Cargo.toml
+++ b/stabby-macros/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "stabby-macros"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = { workspace = true }
 license = { workspace = true }

--- a/stabby/Cargo.toml
+++ b/stabby/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "stabby"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = { workspace = true }
 license = { workspace = true }

--- a/stabby/src/allocs/mod.rs
+++ b/stabby/src/allocs/mod.rs
@@ -15,4 +15,5 @@
 pub mod borrow;
 pub mod boxed;
 pub mod string;
+pub mod sync;
 pub mod vec;

--- a/stabby/src/allocs/sync.rs
+++ b/stabby/src/allocs/sync.rs
@@ -1,0 +1,146 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! Stable boxed slices and strings!
+
+use alloc::sync::{Arc, Weak};
+use stabby_abi::AccessAs;
+
+use crate::{self as stabby};
+use core::ops::Deref;
+
+#[stabby::stabby]
+pub struct ArcSlice<T> {
+    start: &'static (),
+    len: usize,
+    marker: core::marker::PhantomData<Box<T>>,
+}
+impl<T: Clone> Clone for ArcSlice<T> {
+    fn clone(&self) -> Self {
+        unsafe {
+            Arc::increment_strong_count(self.start as *const () as *const T);
+            core::ptr::read(self)
+        }
+    }
+}
+impl<T> Deref for ArcSlice<T> {
+    type Target = [T];
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::slice::from_raw_parts(self.start as *const () as *const T, self.len) }
+    }
+}
+impl<T> From<Arc<[T]>> for ArcSlice<T> {
+    fn from(value: Arc<[T]>) -> Self {
+        let len = value.len();
+        let value = Arc::into_raw(value);
+        let start = unsafe { &*(value as *const T as *const ()) };
+        Self {
+            start,
+            len,
+            marker: core::marker::PhantomData,
+        }
+    }
+}
+impl<T> From<ArcSlice<T>> for Arc<[T]> {
+    fn from(value: ArcSlice<T>) -> Self {
+        let result = unsafe {
+            Arc::from_raw(core::ptr::slice_from_raw_parts(
+                value.start as *const () as *const T,
+                value.len,
+            ))
+        };
+        core::mem::forget(value);
+        result
+    }
+}
+impl<T> Drop for ArcSlice<T> {
+    fn drop(&mut self) {
+        unsafe { Arc::from_raw(core::ptr::slice_from_raw_parts(self.start, self.len)) };
+    }
+}
+
+#[stabby::stabby]
+pub struct WeakSlice<T> {
+    start: &'static (),
+    len: usize,
+    marker: core::marker::PhantomData<Box<T>>,
+}
+impl<T: Clone> Clone for WeakSlice<T> {
+    fn clone(&self) -> Self {
+        self.ref_as::<Weak<[T]>>().clone().into()
+    }
+}
+impl<T> Deref for WeakSlice<T> {
+    type Target = [T];
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::slice::from_raw_parts(self.start as *const () as *const T, self.len) }
+    }
+}
+impl<T> From<Weak<[T]>> for WeakSlice<T> {
+    fn from(value: Weak<[T]>) -> Self {
+        let len = match value.upgrade() {
+            Some(value) => value.len(),
+            None => 0,
+        };
+        let value = Weak::into_raw(value);
+        let start = unsafe { &*(value as *const T as *const ()) };
+        Self {
+            start,
+            len,
+            marker: core::marker::PhantomData,
+        }
+    }
+}
+impl<T> From<WeakSlice<T>> for Weak<[T]> {
+    fn from(value: WeakSlice<T>) -> Self {
+        let result = unsafe {
+            Weak::from_raw(core::ptr::slice_from_raw_parts(
+                value.start as *const () as *const T,
+                value.len,
+            ))
+        };
+        core::mem::forget(value);
+        result
+    }
+}
+impl<T> Drop for WeakSlice<T> {
+    fn drop(&mut self) {
+        unsafe { Weak::from_raw(core::ptr::slice_from_raw_parts(self.start, self.len)) };
+    }
+}
+
+#[stabby::stabby]
+#[derive(Clone)]
+pub struct ArcStr {
+    inner: ArcSlice<u8>,
+}
+impl Deref for ArcStr {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::str::from_utf8_unchecked(&self.inner) }
+    }
+}
+impl From<Arc<str>> for ArcStr {
+    fn from(value: Arc<str>) -> Self {
+        let value: Arc<[u8]> = value.into();
+        Self {
+            inner: value.into(),
+        }
+    }
+}
+impl From<ArcStr> for Arc<str> {
+    fn from(value: ArcStr) -> Self {
+        unsafe { core::mem::transmute(Arc::<[u8]>::from(value.inner)) }
+    }
+}


### PR DESCRIPTION
Mismatches were spotted between the intended spec of `#[repr(stabby)]` and implementation.

This PR fixes it, as well as fixes the generation of the binary tree of result from the spec which produced imbalanced binary trees.