### PR TITLE
Safe linkage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ authors = ["Pierre Avital <pierre.avital@gmail.com>"]
 license = " EPL-2.0 OR Apache-2.0"
 categories = ["development-tools::ffi", "no-std::no-alloc"]
 repository = "https://github.com/p-avital/stabby"
-readme = "README.md"
+readme = "stabby/README.md"

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ Annotating an `extern` block with this is equivalent to `#[link(...)]`, but the 
 - `host` (paranoid): enables the canary on the compiler host triple which was set by the compiler. The effects n ABI are unproven, but not excluded.
 - `none`: mostly here to let you fully disable canaries, at your own risks.
 
-### `stabby::Library` (Unimplemented)
-A wrapper around `libloading::Library` that also exposes safe symbol getters which will fail if the canaries are absent, or in case of a report mismatch.
+### The `stabby::libloading::StabbyLibrary` trait
+Additional methods for `libloading::Library` that expose symbol getters which will fail if the canaries are absent, or in case of a report mismatch.
+
+These methods are still considered unsafe, but they will reduce the risks of accidentally loading ABI-incompatible code. Reports also act as a runtime type-check, reducing the risk of mistyping a symbol.
 
 ## Async
 Any implementation of `core::future::Future` on a stable type will work regardless of which side of the FFI-boundary that stable type was constructed. However, futures created by async blocks and async functions aren't ABI-stable, so they must be used through trait objects.

--- a/stabby-abi/Cargo.toml
+++ b/stabby-abi/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "stabby-abi"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = { workspace = true }
 license = { workspace = true }
@@ -34,4 +34,4 @@ alloc = []
 unsafe_wakers = []
 
 [dependencies]
-stabby-macros = { path = "../stabby-macros/", version = "0.1.3" }
+stabby-macros = { path = "../stabby-macros/", version = "0.1.4" }

--- a/stabby-abi/src/checked_import.rs
+++ b/stabby-abi/src/checked_import.rs
@@ -1,0 +1,98 @@
+use core::sync::atomic::{AtomicU8, Ordering};
+#[crate::stabby]
+pub struct CheckedImport<F> {
+    checked: AtomicU8,
+    result: core::cell::UnsafeCell<core::mem::MaybeUninit<F>>,
+    checker: unsafe extern "C" fn(&crate::report::TypeReport) -> Option<F>,
+    get_report: unsafe extern "C" fn() -> &'static crate::report::TypeReport,
+    local_report: &'static crate::report::TypeReport,
+}
+unsafe impl<F> Send for CheckedImport<F> {}
+unsafe impl<F> Sync for CheckedImport<F> {}
+
+#[crate::stabby]
+#[derive(Debug, Clone, Copy)]
+pub struct ReportMismatch {
+    pub local: &'static crate::report::TypeReport,
+    pub loaded: &'static crate::report::TypeReport,
+}
+impl core::fmt::Display for ReportMismatch {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self, f)
+    }
+}
+#[cfg(feature = "std")]
+impl std::error::Error for ReportMismatch {}
+
+const UNCHECKED: u8 = 0;
+const VALIDATED: u8 = 1;
+const INVALIDATED: u8 = 2;
+const LOCKED: u8 = 3;
+impl<F> CheckedImport<F> {
+    pub const fn new(
+        checker: unsafe extern "C" fn(&crate::report::TypeReport) -> Option<F>,
+        get_report: unsafe extern "C" fn() -> &'static crate::report::TypeReport,
+        local_report: &'static crate::report::TypeReport,
+    ) -> Self {
+        Self {
+            checked: AtomicU8::new(UNCHECKED),
+            checker,
+            get_report,
+            local_report,
+            result: core::cell::UnsafeCell::new(core::mem::MaybeUninit::uninit()),
+        }
+    }
+    fn error_report(&self) -> ReportMismatch {
+        ReportMismatch {
+            local: self.local_report,
+            loaded: unsafe { (self.get_report)() },
+        }
+    }
+    pub fn as_ref(&self) -> Result<&F, ReportMismatch> {
+        loop {
+            match self.checked.load(Ordering::Relaxed) {
+                UNCHECKED => match unsafe { (self.checker)(self.local_report) } {
+                    Some(result) => {
+                        if self
+                            .checked
+                            .compare_exchange_weak(
+                                UNCHECKED,
+                                LOCKED,
+                                Ordering::SeqCst,
+                                Ordering::Relaxed,
+                            )
+                            .is_ok()
+                        {
+                            unsafe {
+                                (*self.result.get()).write(result);
+                                self.checked.store(VALIDATED, Ordering::SeqCst);
+                                return Ok((*self.result.get()).assume_init_ref());
+                            }
+                        }
+                    }
+                    None => {
+                        self.checked.store(INVALIDATED, Ordering::Relaxed);
+                        return Err(self.error_report());
+                    }
+                },
+                VALIDATED => return Ok(unsafe { (*self.result.get()).assume_init_ref() }),
+                INVALIDATED => return Err(self.error_report()),
+                _ => {}
+            }
+            core::hint::spin_loop();
+        }
+    }
+}
+impl<F> core::ops::Deref for CheckedImport<F> {
+    type Target = F;
+    fn deref(&self) -> &Self::Target {
+        self.as_ref().unwrap()
+    }
+}
+impl<F> Drop for CheckedImport<F> {
+    fn drop(&mut self) {
+        if self.checked.load(Ordering::Relaxed) == VALIDATED {
+            unsafe { self.result.get_mut().assume_init_drop() }
+        }
+    }
+}

--- a/stabby-abi/src/lib.rs
+++ b/stabby-abi/src/lib.rs
@@ -19,7 +19,7 @@ extern crate alloc;
 #[cfg(feature = "alloc")]
 mod allocs;
 
-pub use stabby_macros::{dynptr, export, import, stabby, vtable as vtmacro};
+pub use stabby_macros::{canary_suffixes, dynptr, export, import, stabby, vtable as vtmacro};
 
 use core::fmt::{Debug, Display};
 

--- a/stabby-abi/src/lib.rs
+++ b/stabby-abi/src/lib.rs
@@ -19,7 +19,7 @@ extern crate alloc;
 #[cfg(feature = "alloc")]
 mod allocs;
 
-pub use stabby_macros::{dynptr, stabby, vtable as vtmacro};
+pub use stabby_macros::{dynptr, export, stabby, vtable as vtmacro};
 
 use core::fmt::{Debug, Display};
 
@@ -28,7 +28,7 @@ macro_rules! primitive_report {
     ($name: expr, $ty: ty) => {
         const REPORT: &'static $crate::report::TypeReport = &$crate::report::TypeReport {
             name: $crate::str::Str::new($name),
-            module: $crate::str::Str::new(core::stringify!(core::module_path!())),
+            module: $crate::str::Str::new(core::module_path!()),
             fields: $crate::StableLike::new(Some(&$crate::report::FieldReport {
                 name: $crate::str::Str::new("inner"),
                 ty: <$ty as $crate::IStable>::REPORT,
@@ -41,7 +41,7 @@ macro_rules! primitive_report {
     ($name: expr) => {
         const REPORT: &'static $crate::report::TypeReport = &$crate::report::TypeReport {
             name: $crate::str::Str::new($name),
-            module: $crate::str::Str::new(core::stringify!(core::module_path!())),
+            module: $crate::str::Str::new(core::module_path!()),
             fields: $crate::StableLike::new(None),
             last_break: $crate::report::Version::NEVER,
             tyty: $crate::report::TyTy::Struct,

--- a/stabby-abi/src/lib.rs
+++ b/stabby-abi/src/lib.rs
@@ -19,7 +19,7 @@ extern crate alloc;
 #[cfg(feature = "alloc")]
 mod allocs;
 
-pub use stabby_macros::{dynptr, export, stabby, vtable as vtmacro};
+pub use stabby_macros::{dynptr, export, import, stabby, vtable as vtmacro};
 
 use core::fmt::{Debug, Display};
 
@@ -280,6 +280,7 @@ impl<A, B> Clone for Union<A, B> {
     }
 }
 
+pub mod checked_import;
 pub mod enums;
 pub mod padding;
 pub mod result;

--- a/stabby-abi/src/report.rs
+++ b/stabby-abi/src/report.rs
@@ -29,6 +29,19 @@ pub struct TypeReport {
     pub tyty: TyTy,
 }
 
+impl TypeReport {
+    pub fn is_compatible(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.module == other.module
+            && self.last_break == other.last_break
+            && self.tyty == other.tyty
+            && self
+                .fields()
+                .zip(other.fields())
+                .all(|(s, o)| s.name == o.name && s.ty.is_compatible(o.ty))
+    }
+}
+
 #[crate::stabby]
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/stabby-abi/src/report.rs
+++ b/stabby-abi/src/report.rs
@@ -16,6 +16,20 @@ impl Version {
         dirty: false,
     };
 }
+impl core::fmt::Display for Version {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let Self {
+            major,
+            minor,
+            patch,
+            dirty,
+        } = self;
+        if *dirty {
+            write!(f, "*")?;
+        }
+        write!(f, "{major}.{minor}.{patch}")
+    }
+}
 
 type NextField = StableLike<Option<&'static FieldReport>, usize>;
 
@@ -27,6 +41,23 @@ pub struct TypeReport {
     pub fields: NextField,
     pub last_break: Version,
     pub tyty: TyTy,
+}
+
+impl core::fmt::Display for TypeReport {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let Self {
+            name,
+            module,
+            last_break,
+            tyty,
+            ..
+        } = self;
+        write!(f, "{tyty:?} {module} :: {name} (last_break{last_break}) {{")?;
+        for FieldReport { name, ty, .. } in self.fields() {
+            write!(f, "{name}: {ty}, ")?
+        }
+        write!(f, "}}")
+    }
 }
 
 impl TypeReport {

--- a/stabby-macros/Cargo.toml
+++ b/stabby-macros/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "stabby-macros"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = { workspace = true }
 license = { workspace = true }

--- a/stabby-macros/build.rs
+++ b/stabby-macros/build.rs
@@ -1,0 +1,77 @@
+use std::process::Command;
+
+fn encode(value: String) -> String {
+    value
+}
+
+fn main() -> Result<(), std::io::Error> {
+    use std::{
+        fs::File,
+        io::{BufWriter, Write},
+        path::PathBuf,
+    };
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let output = String::from_utf8(
+        Command::new(rustc)
+            .arg("-v")
+            .arg("-V")
+            .output()
+            .expect("Couldn't get rustc version")
+            .stdout,
+    )
+    .unwrap();
+    let env_vars = PathBuf::from(std::env::var_os("OUT_DIR").unwrap()).join("env_vars.rs");
+    let mut env_vars = BufWriter::new(File::create(env_vars).unwrap());
+    let mut rustc: [u16; 3] = [0; 3];
+    let mut llvm: [u16; 3] = [0; 3];
+    let mut commit = "";
+    for line in output.lines() {
+        let line = line.trim();
+        if let Some(release) = line.strip_prefix("release: ") {
+            for (i, s) in release.split('.').enumerate() {
+                rustc[i] = s.parse().unwrap_or(0);
+            }
+        }
+        if let Some(release) = line.strip_prefix("LLVM version: ") {
+            for (i, s) in release.split('.').enumerate() {
+                llvm[i] = s.parse().unwrap_or(0);
+            }
+        }
+        if let Some(hash) = line.strip_prefix("commit-hash: ") {
+            commit = hash;
+        }
+    }
+    writeln!(
+        env_vars,
+        r#"pub (crate) const RUSTC_COMMIT: &str = "{commit}";"#
+    )?;
+    writeln!(
+        env_vars,
+        "pub (crate) const RUSTC_MAJOR: u16 = {};",
+        rustc[0]
+    )?;
+    writeln!(
+        env_vars,
+        "pub (crate) const RUSTC_MINOR: u16 = {};",
+        rustc[1]
+    )?;
+    writeln!(
+        env_vars,
+        "pub (crate) const RUSTC_PATCH: u16 = {};",
+        rustc[2]
+    )?;
+    // writeln!(env_vars, "pub (crate) const LLVM_MAJOR: u16 = {};", llvm[0])?;
+    // writeln!(env_vars, "pub (crate) const LLVM_MINOR: u16 = {};", llvm[1])?;
+    // writeln!(env_vars, "pub (crate) const LLVM_PATCH: u16 = {};", llvm[2])?;
+    for (key, value) in ["OPT_LEVEL", "DEBUG", "NUM_JOBS", "TARGET", "HOST"]
+        .iter()
+        .filter_map(|&name| std::env::var(name).map_or(None, |val| Some((name, val))))
+    {
+        writeln!(
+            env_vars,
+            r#"pub (crate) const {key}: &str = "{}";"#,
+            encode(value)
+        )?;
+    }
+    Ok(())
+}

--- a/stabby-macros/src/enums.rs
+++ b/stabby-macros/src/enums.rs
@@ -148,7 +148,7 @@ pub fn stabby(
             type HasExactlyOneNiche = #st::B0;
             const REPORT: &'static #st::report::TypeReport = & #st::report::TypeReport {
                 name: #st::str::Str::new(#sident),
-                module: #st::str::Str::new(core::stringify!(core::module_path!())),
+                module: #st::str::Str::new(core::module_path!()),
                 fields: unsafe {#st::StableLike::new(#report)},
                 last_break: #st::report::Version::NEVER,
                 tyty: #st::report::TyTy::Enum(#st::str::Str::new(#repr)),
@@ -338,7 +338,7 @@ pub fn repr_stabby(
             type HasExactlyOneNiche = #st::B0;
             const REPORT: &'static #st::report::TypeReport = & #st::report::TypeReport {
                 name: #st::str::Str::new(#sident),
-                module: #st::str::Str::new(core::stringify!(core::module_path!())),
+                module: #st::str::Str::new(core::module_path!()),
                 fields: unsafe {#st::StableLike::new(#report)},
                 last_break: #st::report::Version::NEVER,
                 tyty: #st::report::TyTy::Enum(#st::str::Str::new("stabby")),

--- a/stabby-macros/src/functions.rs
+++ b/stabby-macros/src/functions.rs
@@ -161,9 +161,9 @@ impl CanarySpec {
         ("none", Self::NONE),
         ("rustc", Self::RUSTC),
         ("opt_level", Self::OPT_LEVEL),
-        ("debug", Self::DEBUG),
-        ("num_jobs", Self::NUM_JOBS),
         ("target", Self::TARGET),
+        ("num_jobs", Self::NUM_JOBS),
+        ("debug", Self::DEBUG),
         ("host", Self::HOST),
     ];
 }

--- a/stabby-macros/src/lib.rs
+++ b/stabby-macros/src/lib.rs
@@ -256,3 +256,8 @@ pub(crate) fn report(
 pub fn export(attrs: TokenStream, fn_spec: TokenStream) -> TokenStream {
     crate::functions::export(attrs, syn::parse(fn_spec).unwrap()).into()
 }
+
+#[proc_macro_attribute]
+pub fn import(attrs: TokenStream, fn_spec: TokenStream) -> TokenStream {
+    crate::functions::import(attrs, syn::parse(fn_spec).unwrap()).into()
+}

--- a/stabby-macros/src/lib.rs
+++ b/stabby-macros/src/lib.rs
@@ -261,3 +261,14 @@ pub fn export(attrs: TokenStream, fn_spec: TokenStream) -> TokenStream {
 pub fn import(attrs: TokenStream, fn_spec: TokenStream) -> TokenStream {
     crate::functions::import(attrs, syn::parse(fn_spec).unwrap()).into()
 }
+
+#[proc_macro]
+pub fn canary_suffixes(_: TokenStream) -> TokenStream {
+    let mut stream = quote::quote!();
+    for (name, spec) in functions::CanarySpec::ARRAY.iter().skip(2) {
+        let id = quote::format_ident!("CANARY_{}", name.to_ascii_uppercase());
+        let suffix = spec.to_string();
+        stream.extend(quote::quote!(pub const #id: &'static str = #suffix;));
+    }
+    stream.into()
+}

--- a/stabby-macros/src/lib.rs
+++ b/stabby-macros/src/lib.rs
@@ -85,7 +85,7 @@ pub fn stabby(stabby_attrs: TokenStream, tokens: TokenStream) -> TokenStream {
             syn::Data::Union(data) => unions::stabby(attrs, vis, ident, generics, data),
         }
     } else if let Ok(fn_spec) = syn::parse(tokens.clone()) {
-        functions::stabby(stabby_attrs, fn_spec)
+        functions::stabby(syn::parse(stabby_attrs).unwrap(), fn_spec)
     } else if let Ok(trait_spec) = syn::parse(tokens.clone()) {
         traits::stabby(trait_spec)
     } else if let Ok(async_block) = syn::parse::<syn::ExprAsync>(tokens) {
@@ -250,4 +250,9 @@ pub(crate) fn report(
         };
     }
     (report, report_bounds)
+}
+
+#[proc_macro_attribute]
+pub fn export(attrs: TokenStream, fn_spec: TokenStream) -> TokenStream {
+    crate::functions::export(attrs, syn::parse(fn_spec).unwrap()).into()
 }

--- a/stabby-macros/src/structs.rs
+++ b/stabby-macros/src/structs.rs
@@ -121,7 +121,7 @@ pub fn stabby(
             type HasExactlyOneNiche = <#layout as #st::IStable>::HasExactlyOneNiche;
             const REPORT: &'static #st::report::TypeReport = & #st::report::TypeReport {
                 name: #st::str::Str::new(#sident),
-                module: #st::str::Str::new(core::stringify!(core::module_path!())),
+                module: #st::str::Str::new(core::module_path!()),
                 fields: unsafe{#st::StableLike::new(#report)},
                 last_break: #st::report::Version::NEVER,
                 tyty: #st::report::TyTy::Struct,

--- a/stabby-macros/src/unions.rs
+++ b/stabby-macros/src/unions.rs
@@ -52,7 +52,7 @@ pub fn stabby(
             type HasExactlyOneNiche = #st::B0;
             const REPORT: &'static #st::report::TypeReport = & #st::report::TypeReport {
                 name: #st::str::Str::new(#sident),
-                module: #st::str::Str::new(core::stringify!(core::module_path!())),
+                module: #st::str::Str::new(core::module_path!()),
                 fields: unsafe{#st::StableLike::new(#report)},
                 last_break: #st::report::Version::NEVER,
                 tyty: #st::report::TyTy::Struct,

--- a/stabby/Cargo.toml
+++ b/stabby/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "stabby"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = { workspace = true }
 license = { workspace = true }
@@ -31,10 +31,10 @@ unsafe_wakers = ["stabby-abi/unsafe_wakers"]
 libloading = ["dep:libloading", "std"]
 
 [dependencies]
-stabby-abi = { path = "../stabby-abi/", version = "0.1.5" }
+stabby-abi = { path = "../stabby-abi/", version = "0.1.6" }
 
 lazy_static = "1.4.0"
-libloading = { version = "0.7", optional = true }
+libloading = { version = "0.8", optional = true }
 rustversion = "1.0"
 
 [dev-dependencies]

--- a/stabby/Cargo.toml
+++ b/stabby/Cargo.toml
@@ -28,7 +28,7 @@ default = ["std", "libloading"]
 std = ["alloc"]
 alloc = ["stabby-abi/alloc"]
 unsafe_wakers = ["stabby-abi/unsafe_wakers"]
-libloading = ["dep:libloading"]
+libloading = ["dep:libloading", "std"]
 
 [dependencies]
 stabby-abi = { path = "../stabby-abi/", version = "0.1.5" }

--- a/stabby/Cargo.toml
+++ b/stabby/Cargo.toml
@@ -24,7 +24,7 @@ readme = { workspace = true }
 description = "A Stable ABI for Rust with compact sum-types."
 
 [features]
-default = ["std", "libloading"]
+default = ["std"]
 std = ["alloc"]
 alloc = ["stabby-abi/alloc"]
 unsafe_wakers = ["stabby-abi/unsafe_wakers"]
@@ -43,3 +43,7 @@ smol = "1.3"
 [[example]]
 name = "functions"
 crate-type = ["cdylib"]
+
+[[example]]
+name = "loader"
+required-features = ["libloading"]

--- a/stabby/Cargo.toml
+++ b/stabby/Cargo.toml
@@ -24,15 +24,17 @@ readme = { workspace = true }
 description = "A Stable ABI for Rust with compact sum-types."
 
 [features]
-default = ["std"]
+default = ["std", "libloading"]
 std = ["alloc"]
 alloc = ["stabby-abi/alloc"]
 unsafe_wakers = ["stabby-abi/unsafe_wakers"]
+libloading = ["dep:libloading"]
 
 [dependencies]
 stabby-abi = { path = "../stabby-abi/", version = "0.1.5" }
 
 lazy_static = "1.4.0"
+libloading = { version = "0.7", optional = true }
 rustversion = "1.0"
 
 [dev-dependencies]

--- a/stabby/Cargo.toml
+++ b/stabby/Cargo.toml
@@ -32,7 +32,12 @@ unsafe_wakers = ["stabby-abi/unsafe_wakers"]
 [dependencies]
 stabby-abi = { path = "../stabby-abi/", version = "0.1.5" }
 
+lazy_static = "1.4.0"
 rustversion = "1.0"
 
 [dev-dependencies]
 smol = "1.3"
+
+[[example]]
+name = "functions"
+crate-type = ["cdylib"]

--- a/stabby/README.md
+++ b/stabby/README.md
@@ -73,8 +73,10 @@ Annotating an `extern` block with this is equivalent to `#[link(...)]`, but the 
 - `host` (paranoid): enables the canary on the compiler host triple which was set by the compiler. The effects n ABI are unproven, but not excluded.
 - `none`: mostly here to let you fully disable canaries, at your own risks.
 
-### `stabby::Library` (Unimplemented)
-A wrapper around `libloading::Library` that also exposes safe symbol getters which will fail if the canaries are absent, or in case of a report mismatch.
+### The `stabby::libloading::StabbyLibrary` trait
+Additional methods for `libloading::Library` that expose symbol getters which will fail if the canaries are absent, or in case of a report mismatch.
+
+These methods are still considered unsafe, but they will reduce the risks of accidentally loading ABI-incompatible code. Reports also act as a runtime type-check, reducing the risk of mistyping a symbol.
 
 ## Async
 Any implementation of `core::future::Future` on a stable type will work regardless of which side of the FFI-boundary that stable type was constructed. However, futures created by async blocks and async functions aren't ABI-stable, so they must be used through trait objects.

--- a/stabby/build.rs
+++ b/stabby/build.rs
@@ -47,7 +47,7 @@ unsafe impl<Layout: IStable> IStable for CompilerVersion_{snake_version}<Layout>
 	type HasExactlyOneNiche = Layout::HasExactlyOneNiche;
 	const REPORT: &'static crate::abi::report::TypeReport = &crate::abi::report::TypeReport {{
 		name: crate::abi::str::Str::new("CompilerVersion_{snake_version}"),
-		module: crate::abi::str::Str::new(core::stringify!(core::module_path!())),
+		module: crate::abi::str::Str::new(core::module_path!()),
 		fields: crate::abi::StableLike::new(Some(&crate::abi::report::FieldReport {{
 			name: crate::abi::str::Str::new("inner"),
 			ty: <Layout as crate::abi::IStable>::REPORT,

--- a/stabby/examples/functions.rs
+++ b/stabby/examples/functions.rs
@@ -1,0 +1,19 @@
+#[stabby::export]
+pub extern "C" fn stable_fn(_: u8) {}
+
+#[stabby::export(canaries)]
+pub extern "C" fn unstable_fn(_: &[u8]) {}
+
+// #[stabby::import(canaries = "", name = "test")]
+// extern "C" {
+//     pub fn imported_fn2();
+// }
+// #[stabby::import(name = "test")]
+// extern "C" {
+//     pub fn imported_fn3(_: u8);
+// }
+
+// fn test() {
+//     imported_fn3(4);
+//     unsafe { imported_fn2() }
+// }

--- a/stabby/examples/functions.rs
+++ b/stabby/examples/functions.rs
@@ -1,8 +1,12 @@
 #[stabby::export]
-pub extern "C" fn stable_fn(_: u8) {}
+pub extern "C" fn stable_fn(v: u8) {
+    println!("{v}")
+}
 
 #[stabby::export(canaries)]
-pub extern "C" fn unstable_fn(_: &[u8]) {}
+pub extern "C" fn unstable_fn(v: &[u8]) {
+    println!("{v:?}")
+}
 
 // #[stabby::import(canaries = "", name = "test")]
 // extern "C" {

--- a/stabby/examples/loader.rs
+++ b/stabby/examples/loader.rs
@@ -1,0 +1,16 @@
+#[cfg(feature = "libloading")]
+fn main() {
+    use stabby::libloading::StabbyLibrary;
+    unsafe {
+        let lib = libloading::Library::new("./libfunctions.so").unwrap();
+        let stable_fn = lib.get_stabbied::<extern "C" fn(u8)>(b"stable_fn").unwrap();
+        let unstable_fn = lib
+            .get_canaried::<extern "C" fn(&[u8])>(b"unstable_fn")
+            .unwrap();
+        stable_fn(5);
+        unstable_fn(&[1, 2, 3, 4]);
+    }
+}
+
+#[cfg(not(feature = "libloading"))]
+fn main() {}

--- a/stabby/examples/loader.rs
+++ b/stabby/examples/loader.rs
@@ -11,6 +11,3 @@ fn main() {
         unstable_fn(&[1, 2, 3, 4]);
     }
 }
-
-#[cfg(not(feature = "libloading"))]
-fn main() {}

--- a/stabby/src/allocs/boxed.rs
+++ b/stabby/src/allocs/boxed.rs
@@ -30,6 +30,7 @@ impl<T> BoxedSlice<T> {
         let r = SliceMut {
             start: unsafe { core::mem::transmute_copy(&self.start) },
             len: self.len,
+            marker: core::marker::PhantomData,
         };
         core::mem::forget(self);
         r

--- a/stabby/src/allocs/vec.rs
+++ b/stabby/src/allocs/vec.rs
@@ -43,8 +43,8 @@ impl<T> From<alloc::vec::Vec<T>> for Vec<T> {
 }
 impl<T> From<Vec<T>> for alloc::vec::Vec<T> {
     fn from(value: Vec<T>) -> Self {
-        let slice = BoxedSlice::leak(value.slice);
-        unsafe { alloc::vec::Vec::from_raw_parts(slice.start, slice.len, value.capacity) }
+        let mut slice = BoxedSlice::leak(value.slice);
+        unsafe { alloc::vec::Vec::from_raw_parts(slice.start.as_mut(), slice.len, value.capacity) }
     }
 }
 

--- a/stabby/src/lib.rs
+++ b/stabby/src/lib.rs
@@ -18,7 +18,7 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-pub use stabby_abi::{dynptr, export, stabby, vtmacro as vtable};
+pub use stabby_abi::{dynptr, export, import, stabby, vtmacro as vtable};
 
 pub use stabby_abi as abi;
 

--- a/stabby/src/lib.rs
+++ b/stabby/src/lib.rs
@@ -59,3 +59,11 @@ pub use crate::abi::closure;
 pub use crate::abi::{option, result, slice, str};
 
 pub use crate::abi::{AccessAs, IStable};
+
+#[cfg(feature = "libloading")]
+pub mod libloading {
+    pub struct Library {
+        #[cfg(any(unix, windows))]
+        inner: libloading::Library,
+    }
+}

--- a/stabby/src/lib.rs
+++ b/stabby/src/lib.rs
@@ -61,31 +61,4 @@ pub use crate::abi::{option, result, slice, str};
 pub use crate::abi::{AccessAs, IStable};
 
 #[cfg(all(feature = "libloading", any(unix, windows)))]
-pub mod libloading {
-    pub struct Library {
-        inner: libloading::Library,
-    }
-    impl From<libloading::Library> for Library {
-        fn from(value: libloading::Library) -> Self {
-            Library { inner: value }
-        }
-    }
-    impl Library {
-        const stabbied_suffix: &[u8] = b"_stabbied";
-        const report_suffix: &[u8] = b"_stabbied_report";
-        pub unsafe fn get_stabbied<'a, T: crate::IStable>(
-            &'a self,
-            symbol: &[u8],
-        ) -> Result<libloading::Symbol<'a, T>, Box<dyn std::error::Error + Send + Sync>> {
-            let stabbied = self
-                .inner
-                .get::<extern "C" fn(&crate::abi::report::TypeReport) -> Option<T>>(
-                    &[symbol, Self::stabbied_suffix].concat(),
-                )?;
-            match stabbied(T::REPORT) {
-                Some(f) => Ok(libloading::Symbol::from(f)),
-                None => 
-            }
-        }
-    }
-}
+pub mod libloading;

--- a/stabby/src/lib.rs
+++ b/stabby/src/lib.rs
@@ -60,10 +60,32 @@ pub use crate::abi::{option, result, slice, str};
 
 pub use crate::abi::{AccessAs, IStable};
 
-#[cfg(feature = "libloading")]
+#[cfg(all(feature = "libloading", any(unix, windows)))]
 pub mod libloading {
     pub struct Library {
-        #[cfg(any(unix, windows))]
         inner: libloading::Library,
+    }
+    impl From<libloading::Library> for Library {
+        fn from(value: libloading::Library) -> Self {
+            Library { inner: value }
+        }
+    }
+    impl Library {
+        const stabbied_suffix: &[u8] = b"_stabbied";
+        const report_suffix: &[u8] = b"_stabbied_report";
+        pub unsafe fn get_stabbied<'a, T: crate::IStable>(
+            &'a self,
+            symbol: &[u8],
+        ) -> Result<libloading::Symbol<'a, T>, Box<dyn std::error::Error + Send + Sync>> {
+            let stabbied = self
+                .inner
+                .get::<extern "C" fn(&crate::abi::report::TypeReport) -> Option<T>>(
+                    &[symbol, Self::stabbied_suffix].concat(),
+                )?;
+            match stabbied(T::REPORT) {
+                Some(f) => Ok(libloading::Symbol::from(f)),
+                None => 
+            }
+        }
     }
 }

--- a/stabby/src/lib.rs
+++ b/stabby/src/lib.rs
@@ -37,7 +37,7 @@ pub mod tuple;
 /// Futures can be ABI-stable if you wish hard enough
 #[cfg_attr(
     feature = "unsafe_wakers",
-    deprecated = "Warning! you are using the `stabby/unsafe_wakers` feature. This could cause UB if you poll a future received from another shared library! (this API isn't actually deprecated)"
+    deprecated = "Warning! you are using the `stabby/unsafe_wakers` feature. This could cause UB if you poll a future received from another shared library with mismatching ABI! (this API isn't actually deprecated)"
 )]
 pub mod future {
     pub use crate::abi::future::*;

--- a/stabby/src/lib.rs
+++ b/stabby/src/lib.rs
@@ -18,7 +18,7 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-pub use stabby_abi::{dynptr, stabby, vtmacro as vtable};
+pub use stabby_abi::{dynptr, export, stabby, vtmacro as vtable};
 
 pub use stabby_abi as abi;
 

--- a/stabby/src/libloading.rs
+++ b/stabby/src/libloading.rs
@@ -1,0 +1,105 @@
+pub trait StabbyLibrary {
+    /// Gets `symbol` from the library, using stabby's reports to check for compatibility.
+    ///
+    /// The library must have a symbol with the appropriate type named the same way, and marked with `#[stabby::export]`.
+    ///
+    /// # Safety
+    /// Since this function calls foreign code, it is inherently unsafe.
+    unsafe fn get_stabbied<'a, T: crate::IStable>(
+        &'a self,
+        symbol: &[u8],
+    ) -> Result<Symbol<'a, T>, Box<dyn std::error::Error + Send + Sync>>;
+    /// Gets `symbol` from the library, using stabby's canaries to check for compatibility.
+    ///
+    /// The library must have a symbol with the appropriate type named the same way, and marked with `#[stabby::export(canaries)]`.
+    ///
+    /// Note that while canaries greatly improve the chance ABI compatibility, they don't guarantee it.
+    ///
+    /// # Safety
+    /// The symbol on the other side of the FFI boundary cannot be type-checked, and may still have a different
+    /// ABI than expected (although the canaries should greatly reduce that risk).
+    unsafe fn get_canaried<'a, T: crate::IStable>(
+        &'a self,
+        symbol: &[u8],
+    ) -> Result<libloading::Symbol<'a, T>, Box<dyn std::error::Error + Send + Sync>>;
+}
+pub struct Symbol<'a, T> {
+    inner: T,
+    lt: core::marker::PhantomData<&'a ()>,
+}
+impl<'a, T> core::ops::Deref for Symbol<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+mod canaries {
+    stabby_abi::canary_suffixes!();
+}
+const STABBIED_SUFFIX: &[u8] = b"_stabbied";
+const REPORT_SUFFIX: &[u8] = b"_stabbied_report";
+impl StabbyLibrary for libloading::Library {
+    /// Gets `symbol` from the library, using stabby's reports to check for compatibility.
+    ///
+    /// The library must have a symbol with the appropriate type named the same way, and marked with `#[stabby::export]`.
+    ///
+    /// # Safety
+    /// Since this function calls foreign code, it is inherently unsafe.
+    unsafe fn get_stabbied<'a, T: crate::IStable>(
+        &'a self,
+        symbol: &[u8],
+    ) -> Result<Symbol<'a, T>, Box<dyn std::error::Error + Send + Sync>> {
+        let stabbied = self.get::<extern "C" fn(&crate::abi::report::TypeReport) -> Option<T>>(
+            &[symbol, STABBIED_SUFFIX].concat(),
+        )?;
+        match stabbied(T::REPORT) {
+            Some(f) => Ok(Symbol {
+                inner: f,
+                lt: core::marker::PhantomData,
+            }),
+            None => {
+                let report = self
+                    .get::<extern "C" fn() -> &'static crate::abi::report::TypeReport>(
+                        &[symbol, REPORT_SUFFIX].concat(),
+                    )?;
+                let report = report();
+                Err(format!(
+                    "Report mismatch: loader({loader}),  lib({report}",
+                    loader = T::REPORT
+                )
+                .into())
+            }
+        }
+    }
+    /// Gets `symbol` from the library, using stabby's canaries to check for compatibility.
+    ///
+    /// The library must have a symbol with the appropriate type named the same way, and marked with `#[stabby::export(canaries)]`.
+    ///
+    /// Note that while canaries greatly improve the chance ABI compatibility, they don't guarantee it.
+    ///
+    /// # Safety
+    /// The symbol on the other side of the FFI boundary cannot be type-checked, and may still have a different
+    /// ABI than expected (although the canaries should greatly reduce that risk).
+    unsafe fn get_canaried<'a, T: crate::IStable>(
+        &'a self,
+        symbol: &[u8],
+    ) -> Result<libloading::Symbol<'a, T>, Box<dyn std::error::Error + Send + Sync>> {
+        let stabbied = self.get::<T>(symbol)?;
+        for suffix in [
+            canaries::CANARY_RUSTC,
+            canaries::CANARY_OPT_LEVEL,
+            canaries::CANARY_DEBUG,
+            canaries::CANARY_TARGET,
+            canaries::CANARY_NUM_JOBS,
+        ] {
+            if let Err(e) = self.get::<()>(&[symbol, suffix.as_bytes()].concat()) {
+                return Err(format!(
+                    "Canary {symbol}{suffix} not found: {e}",
+                    symbol = std::str::from_utf8_unchecked(symbol)
+                )
+                .into());
+            }
+        }
+        Ok(stabbied)
+    }
+}

--- a/stabby/src/libloading.rs
+++ b/stabby/src/libloading.rs
@@ -18,7 +18,7 @@ pub trait StabbyLibrary {
     /// # Safety
     /// The symbol on the other side of the FFI boundary cannot be type-checked, and may still have a different
     /// ABI than expected (although the canaries should greatly reduce that risk).
-    unsafe fn get_canaried<'a, T: crate::IStable>(
+    unsafe fn get_canaried<'a, T>(
         &'a self,
         symbol: &[u8],
     ) -> Result<libloading::Symbol<'a, T>, Box<dyn std::error::Error + Send + Sync>>;
@@ -80,7 +80,7 @@ impl StabbyLibrary for libloading::Library {
     /// # Safety
     /// The symbol on the other side of the FFI boundary cannot be type-checked, and may still have a different
     /// ABI than expected (although the canaries should greatly reduce that risk).
-    unsafe fn get_canaried<'a, T: crate::IStable>(
+    unsafe fn get_canaried<'a, T>(
         &'a self,
         symbol: &[u8],
     ) -> Result<libloading::Symbol<'a, T>, Box<dyn std::error::Error + Send + Sync>> {
@@ -92,7 +92,7 @@ impl StabbyLibrary for libloading::Library {
             canaries::CANARY_TARGET,
             canaries::CANARY_NUM_JOBS,
         ] {
-            if let Err(e) = self.get::<()>(&[symbol, suffix.as_bytes()].concat()) {
+            if let Err(e) = self.get::<extern "C" fn()>(&[symbol, suffix.as_bytes()].concat()) {
                 return Err(format!(
                     "Canary {symbol}{suffix} not found: {e}",
                     symbol = std::str::from_utf8_unchecked(symbol)

--- a/stabby/tests/functions.rs
+++ b/stabby/tests/functions.rs
@@ -1,9 +1,2 @@
 #[stabby::export]
 extern "C" fn stable_fn(_: u8) {}
-
-#[test]
-fn report() {
-    use stabby::IStable;
-    let report = <extern "C" fn(u8) as IStable>::REPORT;
-    panic!("{:?}", report);
-}

--- a/stabby/tests/functions.rs
+++ b/stabby/tests/functions.rs
@@ -1,2 +1,0 @@
-#[stabby::export]
-extern "C" fn stable_fn(_: u8) {}

--- a/stabby/tests/functions.rs
+++ b/stabby/tests/functions.rs
@@ -1,0 +1,9 @@
+#[stabby::export]
+extern "C" fn stable_fn(_: u8) {}
+
+#[test]
+fn report() {
+    use stabby::IStable;
+    let report = <extern "C" fn(u8) as IStable>::REPORT;
+    panic!("{:?}", report);
+}


### PR DESCRIPTION
Introduces export macros to add reflection or canaries to a function, import macros to use these extra exports to validate linkage, and extensions to libloading to check them at runtime