### PR TITLE
Improve documentation

### DIFF
--- a/stabby-abi/src/typenum2/unsigned.rs
+++ b/stabby-abi/src/typenum2/unsigned.rs
@@ -235,7 +235,10 @@ impl IUnsignedBase for UTerm {
     type _NonZero = Saturator;
 }
 impl IUnsignedBase for Saturator {
+    #[cfg(not(doc))]
     const _U128: u128 = { panic!("Attempted to convert Saturator into u128") };
+    #[cfg(doc)]
+    const _U128: u128 = 0;
     type Bit = B0;
     type Msb = Saturator;
     type _IsUTerm = B1;

--- a/stabby/Cargo.toml
+++ b/stabby/Cargo.toml
@@ -41,4 +41,5 @@ rustversion = "1.0"
 smol = "1.3"
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/stabby/Cargo.toml
+++ b/stabby/Cargo.toml
@@ -39,3 +39,6 @@ rustversion = "1.0"
 
 [dev-dependencies]
 smol = "1.3"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/stabby/src/lib.rs
+++ b/stabby/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -22,9 +23,9 @@ pub use stabby_abi::{dynptr, export, import, stabby, vtmacro as vtable};
 
 pub use stabby_abi as abi;
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", doc))]
 mod allocs;
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", doc))]
 pub use allocs::*;
 
 pub use stabby_abi::{Dyn, DynRef};
@@ -41,15 +42,15 @@ pub mod tuple;
 )]
 pub mod future {
     pub use crate::abi::future::*;
-    #[cfg(feature = "alloc")]
+    #[cfg(any(feature = "alloc", doc))]
     /// A type alias for `dynptr!(Box<dyn Future<Output = Output> + Send + Sync + 'a>)`
     pub type DynFuture<'a, Output> =
         crate::dynptr!(Box<dyn Future<Output = Output> + Send + Sync + 'a>);
-    #[cfg(feature = "alloc")]
+    #[cfg(any(feature = "alloc", doc))]
     /// A type alias for `dynptr!(Box<dyn Future<Output = Output> + Send + 'a>)`
     pub type DynFutureUnsync<'a, Output> =
         crate::dynptr!(Box<dyn Future<Output = Output> + Send + 'a>);
-    #[cfg(feature = "alloc")]
+    #[cfg(any(feature = "alloc", doc))]
     /// A type alias for `dynptr!(Box<dyn Future<Output = Output> + 'a>)`
     pub type DynFutureUnsend<'a, Output> = crate::dynptr!(Box<dyn Future<Output = Output> + 'a>);
 }
@@ -60,5 +61,5 @@ pub use crate::abi::{option, result, slice, str};
 
 pub use crate::abi::{vtable::Any, AccessAs, IStable, IntoSuperTrait};
 
-#[cfg(all(feature = "libloading", any(unix, windows)))]
+#[cfg(any(all(feature = "libloading", any(unix, windows)), doc))]
 pub mod libloading;

--- a/stabby/src/lib.rs
+++ b/stabby/src/lib.rs
@@ -12,11 +12,11 @@
 //   Pierre Avital, <pierre.avital@me.com>
 //
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(any(feature = "std", doc)), no_std)]
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", doc))]
 extern crate alloc;
 
 pub use stabby_abi::{dynptr, export, import, stabby, vtmacro as vtable};

--- a/stabby/src/lib.rs
+++ b/stabby/src/lib.rs
@@ -61,5 +61,5 @@ pub use crate::abi::{option, result, slice, str};
 
 pub use crate::abi::{vtable::Any, AccessAs, IStable, IntoSuperTrait};
 
-#[cfg(any(all(feature = "libloading", any(unix, windows)), doc))]
+#[cfg(all(feature = "libloading", any(unix, windows)))]
 pub mod libloading;


### PR DESCRIPTION
Fixes #30, although I guess documenting `_U128` as 0 whereas it panics in real code is misleading.
Maybe we should add a documentation line for this, what do you think?

Also I forced to document API behind features (like `stabby::libloading`)
because I found some items in your examples that did not appear on docs.rs.


> I state that I was not able to sign ECA with my GitHub private email,
since I wouldn't want to disclose my public email for this particular commit,
and that therefore I grant the permission to copy/merge my PR if accepted