### PR TITLE
Release v6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 6.2.1 (api=1.1.0, abi=1.0.0)
+- Add support for `#[stabby::stabby(version=10, module="my::module")]` to let you change the values in those fields without having to implement the whole trait yourself.
+- Add support for `serde` through the `serde` feature flag.
+- Add conversions between `std` and `stabby` `String`s.
+- Fix an issue where optimized layout checks would prevent compilation due to missing trait bounds.
+- Fix estimation of `IStable::CType` for arrays.
+
 # 6.1.1 (api=1.0.0, abi=1.0.0)
 - Add support for multi-fields variants in `repr(C, u*)` enums.
 	- Deprecate support for `repr(C)` by deprecating any enum that uses it without also specifying a determinant size.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,12 @@ license = " EPL-2.0 OR Apache-2.0"
 categories = ["development-tools::ffi", "no-std::no-alloc"]
 repository = "https://github.com/ZettaScaleLabs/stabby"
 readme = "stabby/README.md"
-version = "6.1.1"                                           # Track
+version = "6.2.1"                                           # Track
 
 [workspace.dependencies]
-stabby-macros = { path = "./stabby-macros/", version = "6.1.1", default-features = false } # Track
-stabby-abi = { path = "./stabby-abi/", version = "6.1.1", default-features = false }       # Track
-stabby = { path = "./stabby/", version = "6.1.1", default-features = false }               # Track
+stabby-macros = { path = "./stabby-macros/", version = "6.2.1", default-features = false } # Track
+stabby-abi = { path = "./stabby-abi/", version = "6.2.1", default-features = false }       # Track
+stabby = { path = "./stabby/", version = "6.2.1", default-features = false }               # Track
 
 abi_stable = "0.11.2"
 criterion = "0.5.1"
@@ -51,5 +51,6 @@ quote = "1.0"
 rand = "0.8.5"
 rustversion = "1.0"
 sha2-const-stable = "0.1.0"
+serde = "1.0.203"
 smol = "2.0.0"
 syn = "1.0"

--- a/stabby-abi/Cargo.toml
+++ b/stabby-abi/Cargo.toml
@@ -45,7 +45,7 @@ stabby-macros.workspace = true
 abi_stable = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }
 rustversion = { workspace = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
 sha2-const-stable = { workspace = true }
 
 [dev-dependencies]

--- a/stabby-abi/Cargo.toml
+++ b/stabby-abi/Cargo.toml
@@ -28,6 +28,7 @@ default = ["std"]
 std = ["libc"]
 libc = ["dep:libc"]
 test = []
+serde = ["dep:serde"]
 
 abi_stable = ["dep:abi_stable"]
 abi_stable-channels = ["abi_stable", "abi_stable/channels"]
@@ -44,6 +45,7 @@ stabby-macros.workspace = true
 abi_stable = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }
 rustversion = { workspace = true }
+serde = { workspace = true, optional = true }
 sha2-const-stable = { workspace = true }
 
 [dev-dependencies]

--- a/stabby-abi/src/alloc/boxed.rs
+++ b/stabby-abi/src/alloc/boxed.rs
@@ -439,12 +439,12 @@ mod serde_impl {
     use super::*;
     use crate::alloc::IAlloc;
     use serde::{Deserialize, Serialize};
-    impl<'a, T: Serialize, Alloc: IAlloc> Serialize for BoxedSlice<T, Alloc> {
+    impl<T: Serialize, Alloc: IAlloc> Serialize for BoxedSlice<T, Alloc> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
         {
-            let slice: &[T] = &*self;
+            let slice: &[T] = self;
             slice.serialize(serializer)
         }
     }
@@ -456,12 +456,12 @@ mod serde_impl {
             crate::alloc::vec::Vec::deserialize(deserializer).map(Into::into)
         }
     }
-    impl<'a, Alloc: IAlloc> Serialize for BoxedStr<Alloc> {
+    impl<Alloc: IAlloc> Serialize for BoxedStr<Alloc> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
         {
-            let slice: &str = &*self;
+            let slice: &str = self;
             slice.serialize(serializer)
         }
     }

--- a/stabby-abi/src/alloc/boxed.rs
+++ b/stabby-abi/src/alloc/boxed.rs
@@ -284,6 +284,18 @@ impl<T, Alloc: IAlloc> BoxedSlice<T, Alloc> {
         (slice, capacity, alloc)
     }
 }
+impl<T, Alloc: IAlloc> core::ops::Deref for BoxedSlice<T, Alloc> {
+    type Target = [T];
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<T, Alloc: IAlloc> core::ops::DerefMut for BoxedSlice<T, Alloc> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_slice_mut()
+    }
+}
 impl<T: Eq, Alloc: IAlloc> Eq for BoxedSlice<T, Alloc> {}
 impl<T: PartialEq, Alloc: IAlloc> PartialEq for BoxedSlice<T, Alloc> {
     fn eq(&self, other: &Self) -> bool {
@@ -421,3 +433,44 @@ impl<T, Alloc: IAlloc> IntoIterator for BoxedSlice<T, Alloc> {
     }
 }
 pub use super::string::BoxedStr;
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::*;
+    use crate::alloc::IAlloc;
+    use serde::{Deserialize, Serialize};
+    impl<'a, T: Serialize, Alloc: IAlloc> Serialize for BoxedSlice<T, Alloc> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let slice: &[T] = &*self;
+            slice.serialize(serializer)
+        }
+    }
+    impl<'a, T: Deserialize<'a>, Alloc: IAlloc + Default> Deserialize<'a> for BoxedSlice<T, Alloc> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'a>,
+        {
+            crate::alloc::vec::Vec::deserialize(deserializer).map(Into::into)
+        }
+    }
+    impl<'a, Alloc: IAlloc> Serialize for BoxedStr<Alloc> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let slice: &str = &*self;
+            slice.serialize(serializer)
+        }
+    }
+    impl<'a, Alloc: IAlloc + Default> Deserialize<'a> for BoxedStr<Alloc> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'a>,
+        {
+            crate::alloc::string::String::deserialize(deserializer).map(Into::into)
+        }
+    }
+}

--- a/stabby-abi/src/alloc/string.rs
+++ b/stabby-abi/src/alloc/string.rs
@@ -366,12 +366,12 @@ mod serde_impl {
     use super::*;
     use crate::alloc::IAlloc;
     use serde::{Deserialize, Serialize};
-    impl<'a, Alloc: IAlloc> Serialize for String<Alloc> {
+    impl<Alloc: IAlloc> Serialize for String<Alloc> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
         {
-            let slice: &str = &*self;
+            let slice: &str = self;
             slice.serialize(serializer)
         }
     }

--- a/stabby-abi/src/alloc/sync.rs
+++ b/stabby-abi/src/alloc/sync.rs
@@ -861,12 +861,12 @@ mod serde_impl {
     use super::*;
     use crate::alloc::IAlloc;
     use serde::{Deserialize, Serialize};
-    impl<'a, T: Serialize, Alloc: IAlloc> Serialize for ArcSlice<T, Alloc> {
+    impl<T: Serialize, Alloc: IAlloc> Serialize for ArcSlice<T, Alloc> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
         {
-            let slice: &[T] = &*self;
+            let slice: &[T] = self;
             slice.serialize(serializer)
         }
     }
@@ -878,12 +878,12 @@ mod serde_impl {
             crate::alloc::vec::Vec::deserialize(deserializer).map(Into::into)
         }
     }
-    impl<'a, Alloc: IAlloc> Serialize for ArcStr<Alloc> {
+    impl<Alloc: IAlloc> Serialize for ArcStr<Alloc> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
         {
-            let slice: &str = &*self;
+            let slice: &str = self;
             slice.serialize(serializer)
         }
     }

--- a/stabby-abi/src/alloc/sync.rs
+++ b/stabby-abi/src/alloc/sync.rs
@@ -855,3 +855,44 @@ impl<T, Alloc: IAlloc> AtomicArc<T, Alloc> {
         }
     }
 }
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::*;
+    use crate::alloc::IAlloc;
+    use serde::{Deserialize, Serialize};
+    impl<'a, T: Serialize, Alloc: IAlloc> Serialize for ArcSlice<T, Alloc> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let slice: &[T] = &*self;
+            slice.serialize(serializer)
+        }
+    }
+    impl<'a, T: Deserialize<'a>, Alloc: IAlloc + Default> Deserialize<'a> for ArcSlice<T, Alloc> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'a>,
+        {
+            crate::alloc::vec::Vec::deserialize(deserializer).map(Into::into)
+        }
+    }
+    impl<'a, Alloc: IAlloc> Serialize for ArcStr<Alloc> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let slice: &str = &*self;
+            slice.serialize(serializer)
+        }
+    }
+    impl<'a, Alloc: IAlloc + Default> Deserialize<'a> for ArcStr<Alloc> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'a>,
+        {
+            crate::alloc::string::String::deserialize(deserializer).map(Into::into)
+        }
+    }
+}

--- a/stabby-abi/src/alloc/vec.rs
+++ b/stabby-abi/src/alloc/vec.rs
@@ -824,12 +824,12 @@ mod serde_impl {
     use super::*;
     use crate::alloc::IAlloc;
     use serde::{de::Visitor, Deserialize, Serialize};
-    impl<'a, T: Serialize, Alloc: IAlloc> Serialize for Vec<T, Alloc> {
+    impl<T: Serialize, Alloc: IAlloc> Serialize for Vec<T, Alloc> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
         {
-            let slice: &[T] = &*self;
+            let slice: &[T] = self;
             slice.serialize(serializer)
         }
     }

--- a/stabby-abi/src/alloc/vec.rs
+++ b/stabby-abi/src/alloc/vec.rs
@@ -818,3 +818,44 @@ fn test() {
 }
 
 pub use super::single_or_vec::SingleOrVec;
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::*;
+    use crate::alloc::IAlloc;
+    use serde::{de::Visitor, Deserialize, Serialize};
+    impl<'a, T: Serialize, Alloc: IAlloc> Serialize for Vec<T, Alloc> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let slice: &[T] = &*self;
+            slice.serialize(serializer)
+        }
+    }
+    impl<'a, T: Deserialize<'a>, Alloc: IAlloc + Default> Deserialize<'a> for Vec<T, Alloc> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'a>,
+        {
+            deserializer.deserialize_seq(VecVisitor(core::marker::PhantomData))
+        }
+    }
+    pub struct VecVisitor<T, Alloc>(core::marker::PhantomData<(T, Alloc)>);
+    impl<'a, T: Deserialize<'a>, Alloc: IAlloc + Default> Visitor<'a> for VecVisitor<T, Alloc> {
+        type Value = Vec<T, Alloc>;
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("A sequence")
+        }
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'a>,
+        {
+            let mut this = Vec::with_capacity_in(seq.size_hint().unwrap_or(0), Alloc::default());
+            while let Some(v) = seq.next_element()? {
+                this.push(v);
+            }
+            Ok(this)
+        }
+    }
+}

--- a/stabby-abi/src/istable.rs
+++ b/stabby-abi/src/istable.rs
@@ -513,7 +513,7 @@ impl<O1: Unsigned, T1, O2: Unsigned, T2, R2: IBitMask> IncludesComputer<(O1, T1,
 unsafe impl<A: IStable, B: IStable> IStable for Union<A, B> {
     type ForbiddenValues = End;
     type UnusedBits = End;
-    type Size = <A::Size as Unsigned>::Max<B::Size>;
+    type Size = <<A::Size as Unsigned>::Max<B::Size> as Unsigned>::NextMultipleOf<Self::Align>;
     type Align = <A::Align as Alignment>::Max<B::Align>;
     type HasExactlyOneNiche = B0;
     type ContainsIndirections = <A::ContainsIndirections as Bit>::Or<B::ContainsIndirections>;

--- a/stabby-abi/src/num.rs
+++ b/stabby-abi/src/num.rs
@@ -1,3 +1,4 @@
+
 /// Returned when using [`core::convert::TryInto`] on the illegal value of a restricted integer.
 #[crate::stabby]
 #[derive(Clone, Copy, Default, Debug, Ord, PartialEq, PartialOrd, Eq, Hash)]

--- a/stabby-abi/src/num.rs
+++ b/stabby-abi/src/num.rs
@@ -1,4 +1,3 @@
-
 /// Returned when using [`core::convert::TryInto`] on the illegal value of a restricted integer.
 #[crate::stabby]
 #[derive(Clone, Copy, Default, Debug, Ord, PartialEq, PartialOrd, Eq, Hash)]

--- a/stabby-abi/src/option.rs
+++ b/stabby-abi/src/option.rs
@@ -179,3 +179,32 @@ where
         self.unwrap_or_else(|| panic!("Option::unwrap called on None"))
     }
 }
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    impl<Ok: Serialize> Serialize for Option<Ok>
+    where
+        Ok: IDeterminantProvider<()>,
+    {
+        fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let this = self.as_ref();
+            this.serialize(serializer)
+        }
+    }
+    impl<'a, Ok: IDeterminantProvider<()>> Deserialize<'a> for Option<Ok>
+    where
+        core::option::Option<Ok>: Deserialize<'a>,
+    {
+        fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'a>,
+        {
+            Ok(core::option::Option::<Ok>::deserialize(deserializer)?.into())
+        }
+    }
+}

--- a/stabby-abi/src/result.rs
+++ b/stabby-abi/src/result.rs
@@ -549,3 +549,33 @@ where
         }
     }
 }
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    impl<Ok: Serialize, Err: Serialize> Serialize for Result<Ok, Err>
+    where
+        Ok: IDeterminantProvider<Err>,
+        Err: IStable,
+    {
+        fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let this: core::result::Result<_, _> = self.as_ref().into();
+            this.serialize(serializer)
+        }
+    }
+    impl<'a, Ok: IDeterminantProvider<Err>, Err: IStable> Deserialize<'a> for Result<Ok, Err>
+    where
+        core::result::Result<Ok, Err>: Deserialize<'a>,
+    {
+        fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'a>,
+        {
+            Ok(core::result::Result::<Ok, Err>::deserialize(deserializer)?.into())
+        }
+    }
+}

--- a/stabby-abi/src/result.rs
+++ b/stabby-abi/src/result.rs
@@ -563,7 +563,7 @@ mod serde_impl {
         where
             S: serde::Serializer,
         {
-            let this: core::result::Result<_, _> = self.as_ref().into();
+            let this: core::result::Result<_, _> = self.as_ref();
             this.serialize(serializer)
         }
     }

--- a/stabby-abi/src/slice.rs
+++ b/stabby-abi/src/slice.rs
@@ -205,7 +205,7 @@ mod serde_impl {
         where
             S: serde::Serializer,
         {
-            let slice: &[T] = &*self;
+            let slice: &[T] = self;
             slice.serialize(serializer)
         }
     }
@@ -214,7 +214,7 @@ mod serde_impl {
         where
             S: serde::Serializer,
         {
-            let slice: &[T] = &*self;
+            let slice: &[T] = self;
             slice.serialize(serializer)
         }
     }

--- a/stabby-abi/src/slice.rs
+++ b/stabby-abi/src/slice.rs
@@ -195,3 +195,48 @@ impl<'a, T> From<SliceMut<'a, T>> for &'a [T] {
         unsafe { core::slice::from_raw_parts(value.start.as_mut(), value.len) }
     }
 }
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::*;
+    use serde::{de::Visitor, Deserialize, Serialize};
+    impl<'a, T: Serialize> Serialize for Slice<'a, T> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let slice: &[T] = &*self;
+            slice.serialize(serializer)
+        }
+    }
+    impl<'a, T: Serialize> Serialize for SliceMut<'a, T> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let slice: &[T] = &*self;
+            slice.serialize(serializer)
+        }
+    }
+    impl<'a> Deserialize<'a> for Slice<'a, u8> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'a>,
+        {
+            deserializer.deserialize_bytes(BytesVisitor(core::marker::PhantomData))
+        }
+    }
+    struct BytesVisitor<'a>(core::marker::PhantomData<Slice<'a, u8>>);
+    impl<'a> Visitor<'a> for BytesVisitor<'a> {
+        type Value = Slice<'a, u8>;
+        fn visit_borrowed_bytes<E>(self, v: &'a [u8]) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(v.into())
+        }
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "A borrowed_str")
+        }
+    }
+}

--- a/stabby-abi/src/stable_impls/mod.rs
+++ b/stabby-abi/src/stable_impls/mod.rs
@@ -731,7 +731,7 @@ macro_rules! sliceimpl {
                 <<$size as Unsigned>::Equal<U1> as Bit>::SaddTernary<T::HasExactlyOneNiche, Saturator>,
             >;
             type ContainsIndirections = T::ContainsIndirections;
-            type CType = T::CType;
+            type CType = [T::CType; <$size as Unsigned>::USIZE];
             primitive_report!(ARRAY_NAME[<$size as Unsigned>::USIZE], T);
         }
     };

--- a/stabby-abi/src/str.rs
+++ b/stabby-abi/src/str.rs
@@ -53,7 +53,7 @@ impl<'a> From<Str<'a>> for &'a str {
 }
 impl AsRef<str> for Str<'_> {
     fn as_ref(&self) -> &str {
-        &*self
+        self
     }
 }
 impl<'a> Deref for Str<'a> {
@@ -85,7 +85,7 @@ pub struct StrMut<'a> {
 }
 impl AsRef<str> for StrMut<'_> {
     fn as_ref(&self) -> &str {
-        &*self
+        self
     }
 }
 impl<'a> Deref for StrMut<'a> {
@@ -134,7 +134,7 @@ mod serde_impl {
         where
             S: serde::Serializer,
         {
-            serializer.serialize_str(&*self)
+            serializer.serialize_str(self)
         }
     }
     impl<'a> Serialize for StrMut<'a> {
@@ -142,7 +142,7 @@ mod serde_impl {
         where
             S: serde::Serializer,
         {
-            serializer.serialize_str(&*self)
+            serializer.serialize_str(self)
         }
     }
     impl<'a> Deserialize<'a> for Str<'a> {

--- a/stabby-macros/src/unions.rs
+++ b/stabby-macros/src/unions.rs
@@ -15,28 +15,64 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Attribute, DataUnion, Generics, Ident, Visibility};
+
+struct Args {
+    version: u32,
+    module: proc_macro2::TokenStream,
+}
+impl syn::parse::Parse for Args {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut this = Args {
+            version: 0,
+            module: quote!(),
+        };
+        while !input.is_empty() {
+            let ident: Ident = input.parse()?;
+            match ident.to_string().as_str() {
+                "version" => {
+                    input.parse::<syn::Token!(=)>()?;
+                    this.version = input.parse::<syn::LitInt>()?.to_string().parse().unwrap();
+                }
+                "module" => {
+                    input.parse::<syn::Token!(=)>()?;
+                    while !input.is_empty() {
+                        if input.peek(syn::Token!(,)) {
+                            break;
+                        }
+                        let token: proc_macro2::TokenTree = input.parse()?;
+                        this.module.extend(Some(token))
+                    }
+                }
+                _ => return Err(input.error("Unknown stabby attribute {ident}")),
+            }
+            _ = input.parse::<syn::Token!(,)>();
+        }
+        Ok(this)
+    }
+}
 pub fn stabby(
     attrs: Vec<Attribute>,
     vis: Visibility,
     ident: Ident,
     generics: Generics,
     data: DataUnion,
+    stabby_attrs: &proc_macro::TokenStream,
 ) -> TokenStream {
     let st = crate::tl_mod();
     let DataUnion {
         union_token: _,
         fields,
     } = &data;
+    let Args { version, module } = syn::parse(stabby_attrs.clone()).unwrap();
     let unbound_generics = &generics.params;
     let mut layout = quote!(());
-    let mut report = Vec::new();
+    let mut report = crate::Report::r#union(ident.to_string(), version, module);
     for field in &fields.named {
         let ty = &field.ty;
         layout = quote!(#st::Union<#layout, #ty>);
-        report.push((field.ident.as_ref().unwrap().to_string(), ty));
+        report.add_field(field.ident.as_ref().unwrap().to_string(), ty);
     }
-    let sident = format!("{ident}");
-    let (report, report_bounds) = crate::report(&report);
+    let report_bounds = report.bounds();
     quote! {
         #(#attrs)*
         #[repr(C)]
@@ -52,13 +88,7 @@ pub fn stabby(
             type HasExactlyOneNiche = #st::B0;
             type ContainsIndirections =  <#layout as #st::IStable>::ContainsIndirections;
             type CType = <#layout as #st::IStable>::CType;
-            const REPORT: &'static #st::report::TypeReport = & #st::report::TypeReport {
-                name: #st::str::Str::new(#sident),
-                module: #st::str::Str::new(core::module_path!()),
-                fields: unsafe{#st::StableLike::new(#report)},
-                version: 0,
-                tyty: #st::report::TyTy::Struct,
-            };
+            const REPORT: &'static #st::report::TypeReport = & #report;
             const ID: u64 = #st::report::gen_id(Self::REPORT);
         }
     }

--- a/stabby/Cargo.toml
+++ b/stabby/Cargo.toml
@@ -24,13 +24,14 @@ readme = { workspace = true }
 description = "A Stable ABI for Rust with compact sum-types."
 
 [features]
-default = ["std", "libc"]
+default = ["std", "libc", "serde"]
 std = ["libc", "stabby-abi/std"]
 libloading = ["dep:libloading", "std"]
 libc = ["stabby-abi/libc"]
+serde = ["stabby-abi/serde"]
 
 [dependencies]
-stabby-abi = { workspace = true }
+stabby-abi = { workspace = true, default-features = false }
 
 lazy_static = { workspace = true }
 libloading = { workspace = true, optional = true }


### PR DESCRIPTION
- Add support for `#[stabby::stabby(version=10, module="my::module")]` to let you change the values in those fields without having to implement the whole trait yourself.
- Add support for `serde` through the `serde` feature flag.
- Add conversions between `std` and `stabby` `String`s.
- Fix an issue where optimized layout checks would prevent compilation due to missing trait bounds.
- Fix estimation of `IStable::CType` for arrays.