### PR TITLE
v6.2.2 (api=1.1.1, abi=1.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 6.2.2 (api=1.1.1, abi=1.0.0)
+- Relax many dependency requirements to help avoid conflicts with crates that pin them
+
 # 6.4.1-rc1 (api=1.2.0, abi=1.0.0)
 - Found out that `libc` doesn't expose any allocation primitives for `wasm` targets.
 	- These targets now have a poor man's allocator. Be warned that while ABI-stable, this allocator is trivial and probably bad.  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,25 @@ license = " EPL-2.0 OR Apache-2.0"
 categories = ["development-tools::ffi", "no-std::no-alloc"]
 repository = "https://github.com/ZettaScaleLabs/stabby"
 readme = "stabby/README.md"
-version = "6.4.1-rc1"                                           # Track
+version = "6.2.2"                                       # Track
 
 [workspace.dependencies]
-stabby-macros = { path = "./stabby-macros/", version = "6.4.1-rc1", default-features = false } # Track
-stabby-abi = { path = "./stabby-abi/", version = "6.4.1-rc1", default-features = false }       # Track
-stabby = { path = "./stabby/", version = "6.4.1-rc1", default-features = false }               # Track
+stabby-macros = { path = "./stabby-macros/", version = "6.2.2", default-features = false } # Track
+stabby-abi = { path = "./stabby-abi/", version = "6.2.2", default-features = false }       # Track
+stabby = { path = "./stabby/", version = "6.2.2", default-features = false }               # Track
 
-abi_stable = "0.11.2"
-criterion = "0.5.1"
-lazy_static = "1.4.0"
+abi_stable = "0.11.0"
 libc = "0.2"
-libloading = "0.8"
+libloading = ">=0.7.3, <0.9"
 proc-macro2 = "1.0"
-proc-macro-crate = "3.1.0"
+proc-macro-crate = ">=1, <4"
 quote = "1.0"
-rand = "0.8.5"
-rustversion = "1.0"
-sha2-const-stable = "0.1.0"
+rustversion = "<2"
+sha2-const-stable = "0.1"
+syn = "1.0.86"
+
+# dev-dependencies
+criterion = "0.5.1"
+rand = "0.8"
 serde = "1.0.203"
-smol = "2.0.0"
-syn = "1.0"
+smol = ">=1, <3"

--- a/examples/libloading/Cargo.toml
+++ b/examples/libloading/Cargo.toml
@@ -21,4 +21,4 @@ edition = "2021"
 
 [dependencies]
 stabby = { workspace = true, features = ["libloading"] }
-libloading = "0.8"
+libloading = { workspace = true }

--- a/stabby/Cargo.toml
+++ b/stabby/Cargo.toml
@@ -33,7 +33,6 @@ serde = ["stabby-abi/serde"]
 [dependencies]
 stabby-abi = { workspace = true, default-features = false }
 
-lazy_static = { workspace = true }
 libloading = { workspace = true, optional = true }
 rustversion = { workspace = true }
 


### PR DESCRIPTION
# 6.2.2 (api=1.1.1, abi=1.0.0)
- Relax many dependency requirements to help avoid conflicts with crates that pin them