### PR TITLE
Enable building with non-rustup toolchains

### DIFF
--- a/stabby-abi/Cargo.toml
+++ b/stabby-abi/Cargo.toml
@@ -53,5 +53,8 @@ sha2-const-stable = { workspace = true }
 [dev-dependencies]
 rand = { workspace = true }
 
+[build-dependencies]
+rustc_version = "0.4.1"
+
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "docsrs"]

--- a/stabby-abi/build.rs
+++ b/stabby-abi/build.rs
@@ -19,6 +19,8 @@ use std::{
     path::PathBuf,
 };
 
+use rustc_version::{version_meta, Channel};
+
 fn u(mut i: u128) -> String {
     let mut result = "UTerm".into();
     let mut ids = Vec::new();
@@ -132,9 +134,7 @@ fn main() {
             println!(r#"cargo:rustc-cfg=stabby_default_alloc="disabled""#);
         }
     }
-    if let Ok(toolchain) = std::env::var("RUSTUP_TOOLCHAIN") {
-        if toolchain.starts_with("nightly") {
-            println!("cargo:rustc-cfg=stabby_nightly");
-        }
+    if let Channel::Nightly = version_meta().unwrap().channel {
+        println!("cargo:rustc-cfg=stabby_nightly");
     }
 }


### PR DESCRIPTION
Currently stabby fails to build on nightly if the user's toolchain is not installed by rustup.