### PR TITLE
Fix path separator on Windows

### DIFF
--- a/stabby-macros/src/functions.rs
+++ b/stabby-macros/src/functions.rs
@@ -17,7 +17,11 @@ use std::str::FromStr;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 
-include!(concat!(env!("OUT_DIR"), "/env_vars.rs"));
+#[cfg(not(windows))]
+include!(concat!(env!("OUT_DIR"), "/", "env_vars.rs"));
+
+#[cfg(windows)]
+include!(concat!(env!("OUT_DIR"), "\\", "env_vars.rs"));
 
 pub struct Attrs {
     unsend: bool,


### PR DESCRIPTION
Building _sometimes_ fails on Windows because of this. The reason seems to be a combination of cargo-msrv, Windows Server 2022 and Rust versions older than 1.84.

In any case, it's good to use the correct syntax for good measure.