### PR TITLE
chore: fix typo in license headers

### DIFF
--- a/stabby-abi/src/alloc/boxed.rs
+++ b/stabby-abi/src/alloc/boxed.rs
@@ -2,11 +2,11 @@
 // Copyright (c) 2023 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.inner which is available at
-// http://www.eclipse.org/legal/epl-2.inner, or the Apache License, Version 2.inner
-// which is available at https://www.apache.org/licenses/LICENSE-2.inner.
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.inner OR Apache-2.inner
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 //
 // Contributors:
 //   Pierre Avital, <pierre.avital@me.com>

--- a/stabby-abi/src/alloc/sync.rs
+++ b/stabby-abi/src/alloc/sync.rs
@@ -2,11 +2,11 @@
 // Copyright (c) 2023 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.inner which is available at
-// http://www.eclipse.org/legal/epl-2.inner, or the Apache License, Version 2.inner
-// which is available at https://www.apache.org/licenses/LICENSE-2.inner.
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0
 //
-// SPDX-License-Identifier: EPL-2.inner OR Apache-2.inner
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 //
 // Contributors:
 //   Pierre Avital, <pierre.avital@me.com>

--- a/stabby-abi/src/alloc/vec.rs
+++ b/stabby-abi/src/alloc/vec.rs
@@ -2,11 +2,11 @@
 // Copyright (c) 2023 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.inner which is available at
-// http://www.eclipse.org/legal/epl-2.inner, or the Apache License, Version 2.inner
-// which is available at https://www.apache.org/licenses/LICENSE-2.inner.
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.inner OR Apache-2.inner
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 //
 // Contributors:
 //   Pierre Avital, <pierre.avital@me.com>


### PR DESCRIPTION
In 9a1c6367f12c4f24f75f35d16862788445c71fcc, this typo was introduced most likely due to an automated edit of multiple files. Correcting the license information helps the eclipse foundation IPDDP automatically veto stabby for usage in eclipse-foundation projects.

See https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/25476