### PR TITLE
fix: fix lifetime annotation on DynRef

### DIFF
--- a/stabby-abi/src/fatptr.rs
+++ b/stabby-abi/src/fatptr.rs
@@ -435,7 +435,7 @@ impl<P: IPtrOwned, Vt: HasDropVt> Drop for Dyn<'_, P, Vt> {
     }
 }
 
-impl<'a, T, Vt: Copy + IConstConstructor<'a, T>> From<&'a T> for DynRef<'a, Vt> {
+impl<'a, T, Vt: Copy + IConstConstructor<'static, T>> From<&'a T> for DynRef<'a, Vt> {
     fn from(value: &'a T) -> Self {
         DynRef {
             ptr: value.into(),

--- a/stabby/src/tests/traits.rs
+++ b/stabby/src/tests/traits.rs
@@ -150,6 +150,13 @@ fn dyn_traits() {
 }
 
 #[test]
+fn dyn_ref_traits() {
+    let value = 6u8;
+    let dyn_ref = <stabby::dynptr!(&'_ dyn MyTrait2)>::from(&value);
+    assert_eq!(dyn_ref.do_stuff2(), 6);
+}
+
+#[test]
 fn arc_traits() {
     use stabby::sync::Arc;
     let boxed = Arc::new(6u8);


### PR DESCRIPTION
which allows creating a DynRef via dynptr! from non-static values

btw, I tried to do more traits at once in the test, but `dynptr!(&'_ dyn MyTrait2 + MyTrait3)` or any other spelling i tried doesn't seem to work. is that a dynptr! limitation?

fixes #119 