### PR TITLE
fix: traits with lifetimes

### DIFF
--- a/stabby-macros/src/traits.rs
+++ b/stabby-macros/src/traits.rs
@@ -742,7 +742,6 @@ impl DynTraitDescription<'_> {
                         }
                     }
                     #ext_ident :: < StabbyArbitraryType, #(#dyntrait_types,)* #(#unbound_trait_types,)* #(#unbound_trait_consts,)*  > as for <
-                    #(#trait_lts,)*
                     #(#arg_lts,)*
                 > #unsafety #abi fn (#receiver, ::core::marker::PhantomData<&#receiver_lt &'stabby_vt_lt ()>, #(#arg_tys,)*) #output
                 }));
@@ -807,6 +806,7 @@ impl DynTraitDescription<'_> {
             where
                 StabbyArbitraryType: #trait_id <#(#unbound_trait_lts,)* #(#unbound_trait_types,)* #(#unbound_trait_consts,)* #(#trait_to_vt_bindings,)* >,
                 #(#vt_bounds)*
+                #(#trait_lts: 'stabby_vt_lt,)*
                 #(#unbound_trait_types: 'stabby_vt_lt,)*
                 #(#dyntrait_types: 'stabby_vt_lt,)* {
                 #[doc = #vt_doc]

--- a/stabby/src/tests/traits.rs
+++ b/stabby/src/tests/traits.rs
@@ -109,6 +109,13 @@ impl MyTrait3<Box<()>> for u16 {
 }
 
 #[stabby::stabby(checked)]
+pub trait MyTraitWithLt<'a> {
+    extern "C" fn return_lt(&self) -> &'a u8;
+    extern "C" fn take_and_return_lt(&self, with: &'a u8) -> &'a u8;
+    extern "C" fn named_and_trait_lt<'b>(&self, a: &'a u8, b: &'b u8);
+}
+
+#[stabby::stabby(checked)]
 pub trait AsyncRead {
     extern "C" fn read<'a>(
         &'a mut self,


### PR DESCRIPTION
i am honestly unsure about both changes here, but they look correct and allow the code to build.

* do not name `trait_lts` in the `for<>` construct in the vtable entry -- because they are already named in the outer scope, in the impl of `StabbyVtable[TraitName]`.

  Looks conceptually correct, but then, the definition of the extern fn is apparently fine with shadowing the same lifetime name, but the cast below it is not?? Like, _should_ we be taking the lifetime from outer scope, or should we instead rename all the trait lifetimes to avoid the name collision?

* bound all `trait_lts` with `'stabby_vt_lt` in `IConstConstructor`.
  I failed to understand why `IConstConstructor<'a>` needs to be bounded by `'a` (or `'stabby_vt_lt` in the generated impl), but _given_ that it is, all of `StabbyVtable...` lifetimes must also be bounded by `'stabby_vt_lt`. Plus, all of its generic _type_ parameters are already bounded by that, so it kinda comes to reason that the lifetimes would be too?