### PR TITLE
Add support for lifetimes and where clauses in trait definitions

### DIFF
--- a/stabby-abi/src/stable_impls/mod.rs
+++ b/stabby-abi/src/stable_impls/mod.rs
@@ -196,15 +196,15 @@ macro_rules! check {
                 write!(b"\r\n");
             }
             match <<$t as IStable>::HasExactlyOneNiche as crate::istable::ISaturatingAdd>::VALUE {
-                crate::istable::SaturatingAddValue::B0 => {
-                    if rust == core::mem::size_of::<Option<$t>>() {
+                crate::istable::SaturatingAddValue::B0
+                    if rust == core::mem::size_of::<Option<$t>>() => {
                         write!(stringify!($t).as_bytes());
                         write!(b"'s niches were mis-evaluated by stabby, this is definitely a bug and may cause UB. Please create an issue using this link: https://github.com/ZettaScaleLabs/stabby/issues/new?title=");
                         write!(stringify!($t).as_bytes());
                         write!(b"%20has%20niches%20but%20stabby%20does%20not%20find%20any");
                         write!(b"\r\n");
                     }
-                }
+
                 crate::istable::SaturatingAddValue::B1 => {
                     if rust != core::mem::size_of::<Option<$t>>() {
                         write!(stringify!($t).as_bytes());

--- a/stabby-macros/src/lib.rs
+++ b/stabby-macros/src/lib.rs
@@ -38,7 +38,7 @@ macro_rules! log {
         let logfile = std::path::PathBuf::from($path);
         use std::io::Write;
         let e = $e;
-        writeln!(crate::logfile(logfile), $pat, e);
+        writeln!(crate::logfile(logfile), $pat, e).unwrap();
         e
     }};
     ($pat: literal, $e: expr) => {

--- a/stabby-macros/src/traits.rs
+++ b/stabby-macros/src/traits.rs
@@ -742,7 +742,6 @@ impl DynTraitDescription<'_> {
                         }
                     }
                     #ext_ident :: < StabbyArbitraryType, #(#dyntrait_types,)* #(#unbound_trait_types,)* #(#unbound_trait_consts,)*  > as for <
-                    #(#trait_lts,)*
                     #(#arg_lts,)*
                 > #unsafety #abi fn (#receiver, ::core::marker::PhantomData<&#receiver_lt &'stabby_vt_lt ()>, #(#arg_tys,)*) #output
                 }));
@@ -807,6 +806,7 @@ impl DynTraitDescription<'_> {
             where
                 StabbyArbitraryType: #trait_id <#(#unbound_trait_lts,)* #(#unbound_trait_types,)* #(#unbound_trait_consts,)* #(#trait_to_vt_bindings,)* >,
                 #(#vt_bounds)*
+                #(#trait_lts: 'stabby_vt_lt,)*
                 #(#unbound_trait_types: 'stabby_vt_lt,)*
                 #(#dyntrait_types: 'stabby_vt_lt,)* {
                 #[doc = #vt_doc]

--- a/stabby-macros/src/traits.rs
+++ b/stabby-macros/src/traits.rs
@@ -52,7 +52,7 @@ impl SelfDependentTypes {
         match elem {
             Ty::Never => Ty::Never,
             Ty::Unit => Ty::Unit,
-            Ty::SelfReferencial(ty) => {
+            Ty::SelfReferential(ty) => {
                 let Some(n) = self.find(ty) else {
                     panic!("Couldn't find type {ty}")
                 };
@@ -360,7 +360,7 @@ impl<'a> From<(&'a mut syn::ItemTrait, bool)> for DynTraitDescription<'a> {
                         next: None,
                     };
                     for bound in bounds {
-                        let target = Ty::SelfReferencial(Box::new(ty.clone()));
+                        let target = Ty::SelfReferential(Box::new(ty.clone()));
                         match bound {
                             syn::TypeParamBound::Trait(syn::TraitBound {
                                 lifetimes,
@@ -393,7 +393,7 @@ impl<'a> From<(&'a mut syn::ItemTrait, bool)> for DynTraitDescription<'a> {
                     this.self_dependent_types.push(ty);
                 }
                 syn::TraitItem::Const(_) => panic!("associated consts are not trait object safe"),
-                syn::TraitItem::Macro(_) => panic!("sabby can't see through macros in traits"),
+                syn::TraitItem::Macro(_) => panic!("stabby can't see through macros in traits"),
                 syn::TraitItem::Verbatim(tt) => {
                     panic!("stabby failed to parse this token stream {}", tt)
                 }
@@ -411,21 +411,22 @@ impl<'a> From<(&'a mut syn::ItemTrait, bool)> for DynTraitDescription<'a> {
 }
 impl DynTraitFn<'_> {
     fn self_dependent_types(&self) -> Vec<Ty> {
-        let mut sdts = self
+        let mut self_dependents = self
             .output
             .as_ref()
             .map_or(Vec::new(), |t| t.self_dependent_types());
         for input in &self.inputs {
-            input.rec_self_dependent_types(&mut sdts);
+            input.rec_self_dependent_types(&mut self_dependents);
         }
-        sdts
+        self_dependents
     }
-    fn stability_cond(&self, sdts: &SelfDependentTypes) -> TokenStream {
+
+    fn stability_cond(&self, self_dependents: &SelfDependentTypes) -> TokenStream {
         let st = crate::tl_mod();
         let Self { inputs, output, .. } = self;
         let mut cond = match output {
             Some(ty) => {
-                let mut uty = sdts.unselfed(ty);
+                let mut uty = self_dependents.unselfed(ty);
                 if uty == *ty {
                     uty.elide_lifetime();
                     quote!(#uty)
@@ -436,7 +437,7 @@ impl DynTraitFn<'_> {
             None => quote!(()),
         };
         for ty in inputs {
-            let mut uty = sdts.unselfed(ty);
+            let mut uty = self_dependents.unselfed(ty);
             if uty == *ty {
                 uty.elide_lifetime();
                 cond = quote!(#st::Union<#cond, #uty>);
@@ -444,7 +445,7 @@ impl DynTraitFn<'_> {
         }
         cond
     }
-    fn field_signature(&self, sdts: &SelfDependentTypes) -> TokenStream {
+    fn field_signature(&self, self_dependents: &SelfDependentTypes) -> TokenStream {
         let st = crate::tl_mod();
         let Self {
             ident: _,
@@ -479,15 +480,15 @@ impl DynTraitFn<'_> {
         } else {
             quote!(#st::AnonymRef<#receiver_lt>)
         };
-        let inputs = inputs.iter().map(|ty| sdts.unselfed(ty));
+        let inputs = inputs.iter().map(|ty| self_dependents.unselfed(ty));
         let output = output.as_ref().map(|ty| {
-            let ty = sdts.unselfed(ty);
+            let ty = self_dependents.unselfed(ty);
             quote!(-> #ty)
         });
         let params = &generics.params;
         let where_clause = &generics.where_clause;
-        let forgen = quote!(for <#receiver_lt_decl #params>);
-        quote!(#forgen #abi #unsafety fn(#receiver, ::core::marker::PhantomData<&#receiver_lt &'stabby_vt_lt ()>, #(#inputs),*) #output #where_clause)
+        let for_generics = quote!(for <#receiver_lt_decl #params>);
+        quote!(#for_generics #abi #unsafety fn(#receiver, ::core::marker::PhantomData<&#receiver_lt &'stabby_vt_lt ()>, #(#inputs),*) #output #where_clause)
     }
 }
 impl DynTraitDescription<'_> {
@@ -502,8 +503,8 @@ impl DynTraitDescription<'_> {
                 syn::GenericParam::Lifetime(lt) => quote!(#generics #lt, ),
                 syn::GenericParam::Type(ty) => {
                     if let Some(sdt) = sdt.take() {
-                        let sdts = sdt.unselfed_iter();
-                        generics = quote!(#generics #(#sdts,)* )
+                        let unselfed_sdt = sdt.unselfed_iter();
+                        generics = quote!(#generics #(#unselfed_sdt,)* )
                     }
                     if BOUNDED {
                         quote!(#generics #ty, )
@@ -621,7 +622,7 @@ impl DynTraitDescription<'_> {
                          lifetimes,
                          bound,
                      }| {
-                        let Ty::SelfReferencial(target) = target else {
+                        let Ty::SelfReferential(target) = target else {
                             return acc;
                         };
                         if &**target == ty {
@@ -995,7 +996,7 @@ enum Ty {
         prefix: TokenStream,
         next: Box<Self>,
     },
-    SelfReferencial(Box<Self>),
+    SelfReferential(Box<Self>),
     Reference {
         lifetime: Option<Lifetime>,
         mutability: Option<Mut>,
@@ -1044,7 +1045,7 @@ impl PartialEq for Ty {
                     next: r_next,
                 },
             ) => l_prefix.to_string() == r_prefix.to_string() && l_next == r_next,
-            (Self::SelfReferencial(l0), Self::SelfReferencial(r0)) => l0 == r0,
+            (Self::SelfReferential(l0), Self::SelfReferential(r0)) => l0 == r0,
             (
                 Self::Reference {
                     lifetime: l_lifetime,
@@ -1152,7 +1153,7 @@ impl quote::ToTokens for Ty {
             Self::Never => tokens.extend(quote!(!)),
             Self::Unit => tokens.extend(quote!(())),
             Self::Arbitrary { prefix, next } => tokens.extend(quote!(#prefix::#next)),
-            Self::SelfReferencial(ty) => tokens.extend(quote!(Self::#ty)),
+            Self::SelfReferential(ty) => tokens.extend(quote!(Self::#ty)),
             Self::Reference {
                 lifetime,
                 mutability,
@@ -1208,7 +1209,7 @@ impl Ty {
             | Ty::Ptr { elem, .. }
             | Ty::LeadingColon { next: elem }
             | Ty::Arbitrary { next: elem, .. }
-            | Ty::SelfReferencial(elem) => elem.elide_lifetime(),
+            | Ty::SelfReferential(elem) => elem.elide_lifetime(),
             Ty::BareFn { .. } => {}
             Ty::Path {
                 arguments, next, ..
@@ -1242,7 +1243,7 @@ impl Ty {
     fn from_iter<'a, T: Iterator<Item = &'a PathSegment> + ExactSizeIterator>(mut iter: T) -> Self {
         let PathSegment { ident, arguments } = iter.next().unwrap();
         if *ident == "Self" {
-            return Self::SelfReferencial(Box::new(Self::from_iter(iter)));
+            return Self::SelfReferential(Box::new(Self::from_iter(iter)));
         }
         let arguments = match arguments {
             PathArguments::None => Arguments::None,
@@ -1271,7 +1272,7 @@ impl Ty {
     }
     fn rec_self_dependent_types(&self, sdts: &mut Vec<Ty>) {
         match self {
-            Ty::SelfReferencial(ty) => sdts.push(ty.as_ref().clone()),
+            Ty::SelfReferential(ty) => sdts.push(ty.as_ref().clone()),
             Ty::Never | Ty::Unit => {}
             Ty::LeadingColon { next: elem }
             | Ty::Arbitrary { next: elem, .. }
@@ -1422,7 +1423,7 @@ pub fn stabby(
     let checked = match stabby_attrs.to_string().as_str() {
         "checked" => true,
         "" => false,
-        _ => panic!("Unkown stabby attributes {stabby_attrs}"),
+        _ => panic!("Unknown stabby attributes {stabby_attrs}"),
     };
     let description: DynTraitDescription = (&mut item_trait, checked).into();
     let vtable = description.vtable();

--- a/stabby-macros/src/traits.rs
+++ b/stabby-macros/src/traits.rs
@@ -336,7 +336,11 @@ impl<'a> From<(&'a mut syn::ItemTrait, bool)> for DynTraitDescription<'a> {
                         ident,
                         generics,
                         bounds,
-                        ..
+                        type_token: _,
+                        semi_token: _,
+                        colon_token: _,
+                        attrs: _,
+                        default: _,
                     } = ty;
                     let ty = Ty::Path {
                         segment: ident.clone(),
@@ -500,7 +504,18 @@ impl DynTraitDescription<'_> {
         let mut sdt = Some(&self.self_dependent_types);
         for generic in &self.generics.params {
             generics = match generic {
-                syn::GenericParam::Lifetime(lt) => quote!(#generics #lt, ),
+                syn::GenericParam::Lifetime(syn::LifetimeDef {
+                    lifetime,
+                    bounds,
+                    colon_token,
+                    attrs: _,
+                }) => {
+                    if BOUNDED {
+                        quote!(#generics #lifetime #colon_token #bounds, )
+                    } else {
+                        quote!(#generics #lifetime, )
+                    }
+                }
                 syn::GenericParam::Type(ty) => {
                     if let Some(sdt) = sdt.take() {
                         let unselfed_sdt = sdt.unselfed_iter();
@@ -524,6 +539,55 @@ impl DynTraitDescription<'_> {
         }
         generics
     }
+    fn where_clauses(&self) -> TokenStream {
+        let mut acc = quote! {};
+        let Some(where_clause) = &self.generics.where_clause else {
+            return acc;
+        };
+        for clause in &where_clause.predicates {
+            acc = match clause {
+                syn::WherePredicate::Type(syn::PredicateType {
+                    lifetimes,
+                    bounded_ty,
+                    colon_token: _,
+                    bounds,
+                }) => {
+                    let unselfed_target = self.self_dependent_types.unselfed(&bounded_ty.into());
+                    if let Some(lifetimes) = lifetimes {
+                        acc = quote! {unselfed_target: #lifetimes, #acc};
+                    }
+                    for bound in bounds.iter() {
+                        match bound {
+                            syn::TypeParamBound::Trait(syn::TraitBound {
+                                paren_token: _,
+                                modifier,
+                                lifetimes,
+                                path,
+                            }) => {
+                                let path = self.self_dependent_types.unselfed(
+                                    &(&syn::Type::Path(syn::TypePath {
+                                        qself: None,
+                                        path: path.clone(),
+                                    }))
+                                        .into(),
+                                );
+                                acc = quote! {#unselfed_target: #modifier #lifetimes #path, #acc}
+                            }
+                            syn::TypeParamBound::Lifetime(lifetime) => {
+                                acc = quote! {#unselfed_target: #lifetime, #acc}
+                            }
+                        }
+                    }
+                    acc
+                }
+                syn::WherePredicate::Lifetime(predicate_lifetime) => {
+                    quote!(#predicate_lifetime, #acc)
+                }
+                syn::WherePredicate::Eq(predicate_eq) => quote!(#predicate_eq, #acc),
+            }
+        }
+        acc
+    }
     fn vtable(&self) -> TokenStream {
         let st = crate::tl_mod();
         let vtid = self.vtid();
@@ -531,7 +595,7 @@ impl DynTraitDescription<'_> {
         let vt_generics = self.vt_generics::<true>();
         let nbvt_generics = self.vt_generics::<false>();
         let vt_attrs = &self.vt_attrs;
-        let vt_bounds = self
+        let mut vt_bounds = self
             .bounds
             .iter()
             .map(
@@ -550,7 +614,18 @@ impl DynTraitDescription<'_> {
                     }
                 },
             )
+            .chain(self.generics.lifetimes().filter_map(
+                |syn::LifetimeDef {
+                     lifetime,
+                     bounds,
+                     colon_token,
+                     attrs: _,
+                 }| {
+                    colon_token.map(|colon_token| quote!(#lifetime #colon_token #bounds, ))
+                },
+            ))
             .collect::<Vec<_>>();
+        vt_bounds.push(self.where_clauses());
         let fns = &self.functions;
         let mut_fns = &self.mut_functions;
         let fn_args = fns

--- a/stabby-macros/src/tyops.rs
+++ b/stabby-macros/src/tyops.rs
@@ -80,7 +80,7 @@ impl From<proc_macro2::TokenStream> for TyExpr {
                             if p.spacing() == Spacing::Joint {
                                 let next = tokens.next().unwrap();
                                 assert!(matches!(next, TokenTree::Punct(p) if p.as_char() == ':'));
-                                path.extend(quote!(::).into_iter());
+                                path.extend(quote!(::));
                                 accept_ident = true;
                                 continue;
                             } else if in_ternary {

--- a/stabby/src/tests/traits.rs
+++ b/stabby/src/tests/traits.rs
@@ -109,6 +109,13 @@ impl MyTrait3<Box<()>> for u16 {
 }
 
 #[stabby::stabby(checked)]
+pub trait MyTraitWithLt<'a> {
+    extern "C" fn return_lt(&self) -> &'a u8;
+    extern "C" fn take_and_return_lt(&self, with: &'a u8) -> &'a u8;
+    extern "C" fn named_and_trait_lt<'b>(&self, a: &'a u8, b: &'b u8);
+}
+
+#[stabby::stabby(checked)]
 pub trait AsyncRead {
     extern "C" fn read<'a>(
         &'a mut self,

--- a/stabby/src/tests/traits.rs
+++ b/stabby/src/tests/traits.rs
@@ -116,6 +116,17 @@ pub trait MyTraitWithLt<'a> {
 }
 
 #[stabby::stabby(checked)]
+pub trait MyTraitWithTwoLt<'a, 'b, G: 'static>
+where
+    'a: 'b,
+    G: core::fmt::Debug,
+{
+    extern "C" fn return_lt(&self) -> &'a u8;
+    extern "C" fn take_and_return_lt(&self, with: &'a u8) -> &'b G;
+    extern "C" fn named_and_trait_lt(&self, a: &'a u8, b: &'b u8);
+}
+
+#[stabby::stabby(checked)]
 pub trait AsyncRead {
     extern "C" fn read<'a>(
         &'a mut self,


### PR DESCRIPTION
Turns out the issue @juliajohannesen mentioned in #124 was actually that stabby completely ignored where clauses in trait definitions.

This PR fixes this while letting @matejcik's contributions from #124 reach main.