### PR TITLE
Fix unsafe fn support in traits

### DIFF
--- a/stabby-macros/src/lib.rs
+++ b/stabby-macros/src/lib.rs
@@ -95,7 +95,7 @@ pub fn stabby(stabby_attrs: TokenStream, tokens: TokenStream) -> TokenStream {
         functions::stabby(syn::parse(stabby_attrs).unwrap(), fn_spec)
     } else if let Ok(trait_spec) = syn::parse(tokens.clone()) {
         traits::stabby(trait_spec, &stabby_attrs)
-    } else if let Ok(async_block) = syn::parse::<syn::ExprAsync>(tokens) {
+    } else if let Ok(async_block) = syn::parse::<syn::ExprAsync>(tokens.clone()) {
         quote!(Box::new(#async_block).into())
     } else {
         panic!("Expected a type declaration, a trait declaration or a function declaration")

--- a/stabby-macros/src/traits.rs
+++ b/stabby-macros/src/traits.rs
@@ -492,7 +492,7 @@ impl DynTraitFn<'_> {
         let params = &generics.params;
         let where_clause = &generics.where_clause;
         let for_generics = quote!(for <#receiver_lt_decl #params>);
-        quote!(#for_generics #abi #unsafety fn(#receiver, ::core::marker::PhantomData<&#receiver_lt &'stabby_vt_lt ()>, #(#inputs),*) #output #where_clause)
+        quote!(#for_generics #unsafety #abi fn(#receiver, ::core::marker::PhantomData<&#receiver_lt &'stabby_vt_lt ()>, #(#inputs),*) #output #where_clause)
     }
 }
 impl DynTraitDescription<'_> {
@@ -1246,10 +1246,8 @@ impl quote::ToTokens for Ty {
                 abi,
                 inputs,
                 output,
-            } => tokens.extend(
-                quote!(#lifetimes #unsafety # abi fn(#(#inputs,)*) -> #output
-                ),
-            ),
+            } => tokens.extend(quote!(#lifetimes #unsafety #abi fn(#(#inputs,)*) -> #output
+            )),
             Self::Path {
                 segment,
                 arguments,

--- a/stabby/src/tests/traits.rs
+++ b/stabby/src/tests/traits.rs
@@ -81,6 +81,7 @@ pub trait MyTrait3<Hi: core::ops::Deref> {
     extern "C" fn gen_stuff3(&mut self, with: Hi) -> Self::A;
     extern "C" fn test(&mut self);
     extern "C" fn test2(&mut self);
+    unsafe extern "C" fn unsafe_test(&mut self);
 }
 
 impl MyTrait3<Box<()>> for u8 {
@@ -94,6 +95,7 @@ impl MyTrait3<Box<()>> for u8 {
     }
     extern "C" fn test(&mut self) {}
     extern "C" fn test2(&mut self) {}
+    unsafe extern "C" fn unsafe_test(&mut self) {}
 }
 impl MyTrait3<Box<()>> for u16 {
     type A = u8;
@@ -106,6 +108,7 @@ impl MyTrait3<Box<()>> for u16 {
     }
     extern "C" fn test(&mut self) {}
     extern "C" fn test2(&mut self) {}
+    unsafe extern "C" fn unsafe_test(&mut self) {}
 }
 
 #[stabby::stabby(checked)]


### PR DESCRIPTION
Closes: #127 

Turns out I had swapped `#unsafety` and `#abi` in the vtable definition of unsafe function, which caused the vtable struct's own `#[stabby::stabby]` pass to fail as `extern "C" unsafe fn` is invalid syntax.

This PR fixes it.