### PR TITLE
Avoid using inspect_err()

### DIFF
--- a/stabby-macros/src/structs.rs
+++ b/stabby-macros/src/structs.rs
@@ -122,9 +122,10 @@ pub fn stabby(
         attr.meta.require_list().ok().and_then(|meta| {
             match (meta.path.is_ident("repr"), &meta.delimiter) {
                 (true, syn::MacroDelimiter::Paren(_)) => {
-                    syn::parse2::<AllowedRepr>(meta.tokens.clone())
-                        .inspect_err(|e| panic!("{e:?} => {meta:?}"))
-                        .ok()
+                    match syn::parse2::<AllowedRepr>(meta.tokens.clone()) {
+                        Ok(value) => Some(value),
+                        Err(e) => panic!("{e:?} => {meta:?}"),
+                    }
                 }
                 _ => None,
             }


### PR DESCRIPTION
In Zenoh, we require to pin cargo 1.75 due to the ROS 2 compatibility, which does not allow `inspect_err`
Although we can pin the stabby version, I prefer not to use `inspect_err` if this is not mandatory.
https://github.com/eclipse-zenoh/zenoh/pull/2639