### PR TITLE
fix(stabby-macros): replace rand::random with deterministic hash for reproducible builds

### DIFF
--- a/stabby-macros/Cargo.toml
+++ b/stabby-macros/Cargo.toml
@@ -34,7 +34,6 @@ proc-macro2 = { workspace = true }
 proc-macro-crate = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["full", "extra-traits"] }
-rand = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/stabby-macros/src/functions.rs
+++ b/stabby-macros/src/functions.rs
@@ -429,7 +429,7 @@ pub fn import(
         attrs, abi, items, ..
     } = &fn_decl;
     let st = crate::tl_mod();
-    let modid = quote::format_ident!("_stabbymod_{}", rand::random::<u128>());
+    let modid = quote::format_ident!("_stabbymod_{}", quote::quote!(#(#items)*).to_string().bytes().fold(0u128, |a, b| a.wrapping_mul(31).wrapping_add(b as u128)));
     let mut externs = Vec::new();
     let mut interns = Vec::new();
     let mut intern_ids = Vec::new();

--- a/stabby-macros/src/functions.rs
+++ b/stabby-macros/src/functions.rs
@@ -429,7 +429,13 @@ pub fn import(
         attrs, abi, items, ..
     } = &fn_decl;
     let st = crate::tl_mod();
-    let modid = quote::format_ident!("_stabbymod_{}", quote::quote!(#(#items)*).to_string().bytes().fold(0u128, |a, b| a.wrapping_mul(31).wrapping_add(b as u128)));
+    let modid = {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        quote::quote!(#(#items)*).to_string().hash(&mut hasher);
+        quote::format_ident!("_stabbymod_{:x}", hasher.finish())
+    };
     let mut externs = Vec::new();
     let mut interns = Vec::new();
     let mut intern_ids = Vec::new();


### PR DESCRIPTION
Fixes #135 

## Problem
`stabby-macros` uses `rand::random::<u128>()` to generate internal module identifiers for `#[stabby::import]` extern blocks, making every dependent crate non-reproducible across builds.

This only manifests in deterministic build environments (Nix, Bazel remote cache, sccache) that cache individual crate artifacts — a cached `zenoh` artifact and a locally-rebuilt downstream crate end up with mismatched baked-in module hashes, causing `E0460`/`E0463`.

## Fix
Replace `rand::random` with a deterministic polynomial hash of the full token stream of the extern block's items. Removes the `rand` dependency from `stabby-macros` entirely.