### PR TITLE
Fix data race in Arc and Weak types

### DIFF
--- a/stabby-abi/src/alloc/sync.rs
+++ b/stabby-abi/src/alloc/sync.rs
@@ -304,11 +304,12 @@ impl<T, Alloc: IAlloc> Drop for Arc<T, Alloc> {
     fn drop(&mut self) {
         if unsafe { self.ptr.prefix() }
             .strong
-            .fetch_sub(1, Ordering::Relaxed)
+            .fetch_sub(1, Ordering::Release)
             != 1
         {
             return;
         }
+        core::sync::atomic::fence(Ordering::Acquire);
         unsafe {
             core::ptr::drop_in_place(self.ptr.as_mut());
             _ = Weak::<T, Alloc>::from_raw(self.ptr);
@@ -401,11 +402,12 @@ impl<T, Alloc: IAlloc> Drop for Weak<T, Alloc> {
     fn drop(&mut self) {
         if unsafe { self.ptr.prefix() }
             .weak
-            .fetch_sub(1, Ordering::Relaxed)
+            .fetch_sub(1, Ordering::Release)
             != 1
         {
             return;
         }
+        core::sync::atomic::fence(Ordering::Acquire);
         unsafe {
             let mut alloc = self.ptr.prefix().alloc.assume_init_read();
             self.ptr.free(&mut alloc)


### PR DESCRIPTION
Refcount decrements for `Arc` use `Relaxed`. This can result in a data race when two threads drop an owned instance of a type duplicated via `Clone`.

## Reproduction:


### Test Case:
```rust
#[test]
fn racy_test() {
    let a: Arc<u64, RustAlloc> = Arc::new_in(7, RustAlloc::new());
    let b = a.clone();
    std::thread::scope(|s| {
        s.spawn(move || drop(b));
        drop(a);
    });
}
```

### Running with Miri:
`MIRIFLAGS="-Zmiri-many-seeds=0..16" cargo +nightly-2025-08-20 miri test -p stabby-abi --test repro`

### Miri output:
```
error: Undefined Behavior: Data race detected between (1) atomic store on thread `race_arc_drop_v` and (2) deallocation on thread `unnamed-3` at alloc688906+0x20
    |
 82 | /         alloc_rs::alloc::dealloc(
 83 | |             dealloc_start,
 84 | |             core::alloc::Layout::from_size_align_unchecked(prev_layout.size, prev_layout.align),
 85 | |         )
    | |_________^ (2) just happened here
```

## Fix:

Synchronise drops of  `std::sync::Arc` using a release ordering to decrement the reference counter and a fence before memory is freed. [This mirrors the synchronisation used by `std::sync::Arc`](https://doc.rust-lang.org/src/alloc/sync.rs.html#2827)



